### PR TITLE
URL does not get encoded correctly

### DIFF
--- a/imgix/__init__.py
+++ b/imgix/__init__.py
@@ -75,6 +75,13 @@ class UrlHelper(object):
         if key in self._parameters:
             del self._parameters[key]
 
+    def _str_is_ascii(self, s):
+        try:
+            s.decode('ascii')
+            return True
+        except:
+            return False
+
     def __str__(self):
         query_pairs = []
 
@@ -88,6 +95,9 @@ class UrlHelper(object):
 
         if not path.startswith("/"):
             path = "/" + path  # Fix web proxy style URLs
+
+        if not self._str_is_ascii(path):
+            path = urllib.quote(self._path)
 
         query = urllib.urlencode(query_pairs)
         if self._sign_key:

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -63,3 +63,8 @@ def test_url_builder_use_https():
     builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=True)
     url = builder.create_url("/users/1.png")
     assert urlparse.urlparse(url).scheme == "https"
+
+def test_utf_8_characters():
+    builder = imgix.UrlBuilder('my-social-network.imgix.net')
+    url = builder.create_url(u'/ǝ'.encode('utf8'))
+    assert url == "http://my-social-network.imgix.net/%C7%9D"

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -68,3 +68,8 @@ def test_utf_8_characters():
     builder = imgix.UrlBuilder('my-social-network.imgix.net')
     url = builder.create_url(u'/ǝ'.encode('utf8'))
     assert url == "http://my-social-network.imgix.net/%C7%9D"
+
+def test_more_involved_utf_8_characters():
+    builder = imgix.UrlBuilder('my-social-network.imgix.net')
+    url = builder.create_url(u'/üsers/1/米国でのパーティーします。.png'.encode('utf8'))
+    assert url == "http://my-social-network.imgix.net/%C3%BCsers/1/%E7%B1%B3%E5%9B%BD%E3%81%A7%E3%81%AE%E3%83%91%E3%83%BC%E3%83%86%E3%82%A3%E3%83%BC%E3%81%97%E3%81%BE%E3%81%99%E3%80%82.png"


### PR DESCRIPTION
Running this snippet
```python
builder = imgix.UrlBuilder(IMGIX_DOMAIN)
builder.create_url(u'ǝ'.encode('utf8'))
```
returns `http://site.imgix.net/\xc7\x9d` on master. Shouldn't it be returning `http://site.imgix.net/%C7%9D` (as it used to)? :-)