### PR TITLE
Default to HTTPS

### DIFF
--- a/imgix/__init__.py
+++ b/imgix/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.0.4'
+__version__ = '0.1.0'
 
 from .urlbuilder import UrlBuilder
 

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -13,7 +13,7 @@ class UrlBuilder(object):
     def __init__(
             self,
             domains,
-            use_https=False,
+            use_https=True,
             sign_key=None,
             sign_mode=SIGNATURE_MODE_QUERY,
             shard_strategy=SHARD_STRATEGY_CRC,

--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -15,7 +15,7 @@ class UrlHelper(object):
             self,
             domain,
             path,
-            scheme="http",
+            scheme="https",
             sign_key=None,
             sign_mode=SIGNATURE_MODE_QUERY,
             sign_with_library_version=True,

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -11,7 +11,7 @@ def default_builder():
 
 
 def default_builder_with_signature():
-    return imgix.UrlBuilder('my-social-network.imgix.net', False, "FOO123bar",
+    return imgix.UrlBuilder('my-social-network.imgix.net', True, "FOO123bar",
                             sign_with_library_version=False)
 
 
@@ -32,20 +32,20 @@ def test_create():
 def test_create_url_with_path():
     builder = default_builder()
     url = builder.create_url("/users/1.png")
-    assert url == "http://my-social-network.imgix.net/users/1.png"
+    assert url == "https://my-social-network.imgix.net/users/1.png"
 
 
 def test_create_url_with_path_and_parameters():
     builder = default_builder()
     url = builder.create_url("/users/1.png", w=400, h=300)
-    assert url == "http://my-social-network.imgix.net/users/1.png?h=300&w=400"
+    assert url == "https://my-social-network.imgix.net/users/1.png?h=300&w=400"
 
 
 def test_create_url_with_path_and_signature():
     builder = default_builder_with_signature()
     url = builder.create_url("/users/1.png")
     assert url == \
-        "http://my-social-network.imgix.net/users/1.png" \
+        "https://my-social-network.imgix.net/users/1.png" \
         "?s=6797c24146142d5b40bde3141fd3600c"
 
 
@@ -53,7 +53,7 @@ def test_create_url_with_path_and_paremeters_and_signature():
     builder = default_builder_with_signature()
     url = builder.create_url("/users/1.png", w=400, h=300)
     assert url == \
-        "http://my-social-network.imgix.net/users/1.png" \
+        "https://my-social-network.imgix.net/users/1.png" \
         "?h=300&w=400&s=1a4e48641614d1109c6a7af51be23d18"
 
 
@@ -61,7 +61,7 @@ def test_create_url_with_fully_qualified_url():
     builder = default_builder_with_signature()
     url = builder.create_url("http://avatars.com/john-smith.png")
     assert url == \
-        "http://my-social-network.imgix.net/"\
+        "https://my-social-network.imgix.net/"\
         "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
         "?s=493a52f008c91416351f8b33d4883135"
 
@@ -70,16 +70,16 @@ def test_create_url_with_fully_qualified_url_and_parameters():
     builder = default_builder_with_signature()
     url = builder.create_url("http://avatars.com/john-smith.png", w=400, h=300)
     assert url == \
-        "http://my-social-network.imgix.net/" \
+        "https://my-social-network.imgix.net/" \
         "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
         "?h=300&w=400&s=a201fe1a3caef4944dcb40f6ce99e746"
 
 
 def test_use_https():
-    # Defaults to http
+    # Defaults to https
     builder = imgix.UrlBuilder('my-social-network.imgix.net')
     url = builder.create_url("/users/1.png")
-    assert urlparse.urlparse(url).scheme == "http"
+    assert urlparse.urlparse(url).scheme == "https"
 
     builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=False)
     url = builder.create_url("/users/1.png")
@@ -97,14 +97,14 @@ def test_use_https():
 def test_utf_8_characters():
     builder = default_builder()
     url = builder.create_url(u'/ǝ')
-    assert url == "http://my-social-network.imgix.net/%C7%9D"
+    assert url == "https://my-social-network.imgix.net/%C7%9D"
 
 
 def test_more_involved_utf_8_characters():
     builder = default_builder()
     url = builder.create_url(u'/üsers/1/米国でのパーティーします。.png')
     assert url == \
-        "http://my-social-network.imgix.net/%C3%BCsers/1/" \
+        "https://my-social-network.imgix.net/%C3%BCsers/1/" \
         "%E7%B1%B3%E5%9B%BD%E3%81%A7%E3%81%AE%E3%83%91%E3%83%BC%E3%83" \
         "%86%E3%82%A3%E3%83%BC%E3%81%97%E3%81%BE%E3%81%99%E3%80%82.png"
 
@@ -112,5 +112,5 @@ def test_more_involved_utf_8_characters():
 def test_signing_url_with_ixlib():
     builder = imgix.UrlBuilder('my-social-network.imgix.net')
     url = builder.create_url("/users/1.png")
-    assert url == "http://my-social-network.imgix.net/users/1.png?ixlib=python-" \
+    assert url == "https://my-social-network.imgix.net/users/1.png?ixlib=python-" \
         + imgix.__version__


### PR DESCRIPTION
[Per the imgix-blueprint](https://github.com/imgix/imgix-blueprint#protocols), we should be using HTTPS by default.