### PR TITLE
Switch `UrlBuilder#create_url` to accept dict instead of kwargs

### DIFF
--- a/imgix/compat.py
+++ b/imgix/compat.py
@@ -3,11 +3,17 @@ try:
     import urllib.parse as urlparse
     from urllib.parse import urlencode
     from urllib.parse import quote
+
+    def iteritems(a_dict):
+        return a_dict.items()
 except ImportError:
     # Python 2.7
     import urlparse
     from urllib import urlencode
     from urllib import quote
 
+    def iteritems(a_dict):
+        return a_dict.iteritems()
 
-__all__ = ['urlparse', 'urlencode', 'quote', ]
+
+__all__ = ['iteritems', 'quote', 'urlparse', 'urlencode']

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -30,7 +30,7 @@ class UrlBuilder(object):
         self._shard_next_index = 0
         self._sign_with_library_version = sign_with_library_version
 
-    def create_url(self, path, **kwargs):
+    def create_url(self, path, opts={}):
         if self._shard_strategy == SHARD_STRATEGY_CRC:
             crc = zlib.crc32(path.encode('utf-8')) & 0xffffffff
             index = crc % len(self._domains)  # Deterministically choose domain
@@ -53,6 +53,6 @@ class UrlBuilder(object):
             sign_key=self._sign_key,
             sign_mode=self._sign_mode,
             sign_with_library_version=self._sign_with_library_version,
-            **kwargs)
+            opts=opts)
 
         return str(url_obj)

--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -19,7 +19,7 @@ class UrlHelper(object):
             sign_key=None,
             sign_mode=SIGNATURE_MODE_QUERY,
             sign_with_library_version=True,
-            **kwargs):
+            opts={}):
 
         self._scheme = scheme
         self._host = domain
@@ -32,7 +32,7 @@ class UrlHelper(object):
 
         self._sign_mode = sign_mode
         self._parameters = {}
-        for key, value in kwargs.items():
+        for key, value in opts.iteritems():
             self.set_parameter(key, value)
 
     @classmethod

--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -4,9 +4,7 @@ import hashlib
 
 from .constants import SIGNATURE_MODE_QUERY
 
-from .compat import urlencode
-from .compat import urlparse
-from .compat import quote
+from .compat import iteritems, quote, urlencode, urlparse
 from ._version import __version__
 
 
@@ -32,7 +30,8 @@ class UrlHelper(object):
 
         self._sign_mode = sign_mode
         self._parameters = {}
-        for key, value in opts.iteritems():
+
+        for key, value in iteritems(opts):
             self.set_parameter(key, value)
 
     @classmethod

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -37,13 +37,13 @@ def test_create_url_with_path():
 
 def test_create_url_with_path_and_parameters():
     builder = default_builder()
-    url = builder.create_url("/users/1.png", w=400, h=300)
+    url = builder.create_url("/users/1.png", {"w": 400, "h": 300})
     assert url == "https://my-social-network.imgix.net/users/1.png?h=300&w=400"
 
 
 def test_create_url_with_splatted_falsy_parameter():
     builder = default_builder()
-    url = builder.create_url("/users/1.png", **{"or": 0})
+    url = builder.create_url("/users/1.png", {"or": 0})
     assert url == "https://my-social-network.imgix.net/users/1.png?or=0"
 
 
@@ -57,7 +57,7 @@ def test_create_url_with_path_and_signature():
 
 def test_create_url_with_path_and_paremeters_and_signature():
     builder = default_builder_with_signature()
-    url = builder.create_url("/users/1.png", w=400, h=300)
+    url = builder.create_url("/users/1.png", {"w": 400, "h": 300})
     assert url == \
         "https://my-social-network.imgix.net/users/1.png" \
         "?h=300&w=400&s=1a4e48641614d1109c6a7af51be23d18"
@@ -74,7 +74,8 @@ def test_create_url_with_fully_qualified_url():
 
 def test_create_url_with_fully_qualified_url_and_parameters():
     builder = default_builder_with_signature()
-    url = builder.create_url("http://avatars.com/john-smith.png", w=400, h=300)
+    url = builder.create_url("http://avatars.com/john-smith.png",
+                             {"w": 400, "h": 300})
     assert url == \
         "https://my-social-network.imgix.net/" \
         "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \


### PR DESCRIPTION
This makes usage more consistent, and eliminates any current/future issues with reserved word collisions (e.g. `or`). 