### PR TITLE
Accept a tuple of domains

### DIFF
--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -19,7 +19,7 @@ class UrlBuilder(object):
             shard_strategy=SHARD_STRATEGY_CRC,
             sign_with_library_version=True):
 
-        if not isinstance(domains, list):
+        if not isinstance(domains, (list, tuple)):
             domains = [domains]
 
         self._domains = domains

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -29,6 +29,30 @@ def test_create():
     assert type(builder) is imgix.UrlBuilder
 
 
+def test_create_accepts_domains_list():
+    domains = [
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net'
+    ]
+    builder = imgix.UrlBuilder(domains)
+    assert builder._domains == domains
+
+
+def test_create_accepts_domains_tuple():
+    domains = (
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net'
+    )
+    builder = imgix.UrlBuilder(domains)
+    assert builder._domains == domains
+
+
+def test_create_accepts_domains_single_str():
+    domains = 'my-social-network-1.imgix.net'
+    builder = imgix.UrlBuilder(domains)
+    assert builder._domains == [domains]
+
+
 def test_create_url_with_path():
     builder = default_builder()
     url = builder.create_url("/users/1.png")


### PR DESCRIPTION
If you pass a tuple of domains to the URLBuilder, an error is raised after a call to `create_url` that doesn't point to the culprit very clearly:

```python
File "/Users/tommi/.virtualenvs/project/lib/python2.7/site-packages/django_imgix/templatetags/imgix_tags.py", line 186, in get_imgix
    url = builder.create_url(image_url, arguments)
  File "/Users/tommi/.virtualenvs/project/lib/python2.7/site-packages/imgix/urlbuilder.py", line 58, in create_url
    return str(url_obj)
  File "/Users/tommi/.virtualenvs/project/lib/python2.7/site-packages/imgix/urlhelper.py", line 116, in __str__
    "", ])
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urlparse.py", line 231, in urlunparse
    return urlunsplit((scheme, netloc, url, query, fragment))
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urlparse.py", line 242, in urlunsplit
    url = '//' + (netloc or '') + url
TypeError: cannot concatenate 'str' and 'tuple' objects
```

This PR modifies the URLBuilder constructor to accept both lists and tuples of domains. Tests are included.