### PR TITLE
Don't delete parameters if value is None or False

### DIFF
--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -90,11 +90,7 @@ class UrlHelper(object):
             If key ends with '64', the value provided will be automatically
             base64 encoded.
         """
-        if value is None or value is False:
-            self.delete_parameter(key)
-            return
-
-        if isinstance(value, (int, float)):
+        if value is None or isinstance(value, (int, float, bool)):
             value = str(value)
 
         if key.endswith('64'):

--- a/tests/test_url_helper.py
+++ b/tests/test_url_helper.py
@@ -181,7 +181,7 @@ def test_set_parameter_with_none_value():
 
     helper.set_parameter("w", None)
     assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300"
+                          "/users/1.png?h=300&w=None"
 
 
 def test_set_parameter_with_false_value():
@@ -191,7 +191,7 @@ def test_set_parameter_with_false_value():
 
     helper.set_parameter("w", False)
     assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300"
+                          "/users/1.png?h=300&w=False"
 
 
 def test_delete_parameter():


### PR DESCRIPTION
Ensure parameters aren't deleted if the associated value
is None or False.