### PR TITLE
Rename `sign_with_library_version` to `include_library_param`

### DIFF
--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -50,20 +50,26 @@ class UrlBuilder(object):
             include_library_param=True):
 
         if sign_with_library_version is not None:
-            warnings.warn('`sign_with_library_version` has been deprecated.' +
+            warnings.warn('`sign_with_library_version` has been deprecated ' +
+                          'and will be removed in the next major version. ' +
                           'Use `include_library_param` instead.',
                           DeprecationWarning, stacklevel=2)
 
         if not isinstance(domains, (list, tuple)):
             domains = [domains]
 
-        include_library = include_library_param or sign_with_library_version
+        # include_library = include_library_param or sign_with_library_version
+        include_library_param = (
+                                    sign_with_library_version
+                                    if sign_with_library_version
+                                    is not None else include_library_param)
+
         self._domains = domains
         self._sign_key = sign_key
         self._use_https = use_https
         self._shard_strategy = shard_strategy
         self._shard_next_index = 0
-        self._include_library_param = include_library
+        self._include_library_param = include_library_param
 
     def create_url(self, path, params={}, opts={}):
         """

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -46,17 +46,24 @@ class UrlBuilder(object):
             use_https=True,
             sign_key=None,
             shard_strategy=SHARD_STRATEGY_CRC,
-            sign_with_library_version=True):
+            sign_with_library_version=None,
+            include_library_param=True):
+
+        if sign_with_library_version is not None:
+            warnings.warn('`sign_with_library_version` has been deprecated.' +
+                          'Use `include_library_param` instead.',
+                          DeprecationWarning, stacklevel=2)
 
         if not isinstance(domains, (list, tuple)):
             domains = [domains]
 
+        include_library_param = include_library_param or sign_with_library_version
         self._domains = domains
         self._sign_key = sign_key
         self._use_https = use_https
         self._shard_strategy = shard_strategy
         self._shard_next_index = 0
-        self._sign_with_library_version = sign_with_library_version
+        self._include_library_param = include_library_param
 
     def create_url(self, path, params={}, opts={}):
         """
@@ -100,7 +107,7 @@ class UrlBuilder(object):
             path,
             scheme,
             sign_key=self._sign_key,
-            sign_with_library_version=self._sign_with_library_version,
+            include_library_param=self._include_library_param,
             params=params)
 
         return str(url_obj)

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -57,13 +57,13 @@ class UrlBuilder(object):
         if not isinstance(domains, (list, tuple)):
             domains = [domains]
 
-        include_library_param = include_library_param or sign_with_library_version
+        include_library = include_library_param or sign_with_library_version
         self._domains = domains
         self._sign_key = sign_key
         self._use_https = use_https
         self._shard_strategy = shard_strategy
         self._shard_next_index = 0
-        self._include_library_param = include_library_param
+        self._include_library_param = include_library
 
     def create_url(self, path, params={}, opts={}):
         """

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -58,7 +58,6 @@ class UrlBuilder(object):
         if not isinstance(domains, (list, tuple)):
             domains = [domains]
 
-        # include_library = include_library_param or sign_with_library_version
         include_library_param = (
                                     sign_with_library_version
                                     if sign_with_library_version

--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -28,9 +28,11 @@ class UrlHelper(object):
         When provided, this key will be used to sign the generated image URLs.
         You can read more about URL signing on our docs:
         https://docs.imgix.com/setup/securing-images
-    sign_with_library_version : bool
+    include_library_param : bool
         If `True`, each created URL is suffixed with 'ixlib' parameter
         indicating the library used for generating the URLs. (default `True`)
+    sign_with_library_version : bool
+        Deprecated
     opts : dict
         Dictionary specifying URL parameters. Non-imgix parameters are
         added to the URL unprocessed. For a complete list of imgix
@@ -48,7 +50,7 @@ class UrlHelper(object):
             path,
             scheme="https",
             sign_key=None,
-            sign_with_library_version=True,
+            include_library_param=True,
             params={},
             opts={}):
         if opts:
@@ -60,8 +62,7 @@ class UrlHelper(object):
         self._host = domain
         self._path = path
         self._sign_key = sign_key
-        self._sign_with_library_version = sign_with_library_version
-
+        self._include_library_param = include_library_param
         self._parameters = {}
 
         for key, value in iteritems(params):
@@ -128,7 +129,7 @@ class UrlHelper(object):
 
         path = self._path
 
-        if self._sign_with_library_version:
+        if self._include_library_param:
             query["ixlib"] = "python-" + __version__
 
         if path.startswith("http"):

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -12,12 +12,12 @@ def _get_domain(url):
 
 def _default_builder():
     return imgix.UrlBuilder('my-social-network.imgix.net',
-                            sign_with_library_version=False)
+                            include_library_param=False)
 
 
 def _default_builder_with_signature():
     return imgix.UrlBuilder('my-social-network.imgix.net', True, "FOO123bar",
-                            sign_with_library_version=False)
+                            include_library_param=False)
 
 
 def test_create():
@@ -278,3 +278,18 @@ def test_shard_strategy_invalid():
 
     # Should not throw an exception
     assert builder.create_url('/users/1.png') is not None
+
+
+def test_create_url_with_sign_with_library_version():
+    with warnings.catch_warnings(record=True) as w:
+        imgix.UrlBuilder('assets.imgix.net', sign_with_library_version=True)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+
+
+def test_create_url_with_include_library_param():
+    url = 'https://assets.imgix.net/image.jpg'
+    ub = imgix.UrlBuilder('assets.imgix.net', include_library_param=False)
+
+    assert url == ub.create_url("image.jpg")

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -280,16 +280,41 @@ def test_shard_strategy_invalid():
     assert builder.create_url('/users/1.png') is not None
 
 
-def test_create_url_with_sign_with_library_version():
+def test_sign_with_library_version_true():
+    url = str("https://assets.imgix.net/image.jpg?ixlib=python-" +
+              imgix._version.__version__)
+
     with warnings.catch_warnings(record=True) as w:
-        imgix.UrlBuilder('assets.imgix.net', sign_with_library_version=True)
+        ub = imgix.UrlBuilder("assets.imgix.net",
+                              sign_with_library_version=True)
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "deprecated" in str(w[-1].message)
+        assert url == ub.create_url("image.jpg")
 
 
-def test_create_url_with_include_library_param():
+def test_sign_with_library_version_false():
+    url = "https://assets.imgix.net/image.jpg"
+
+    with warnings.catch_warnings(record=True) as w:
+        ub = imgix.UrlBuilder("assets.imgix.net",
+                              sign_with_library_version=False)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert url == ub.create_url("image.jpg")
+
+
+def test_include_library_param_true():
+    url = ("https://assets.imgix.net/image.jpg?ixlib=python-" +
+           imgix._version.__version__)
+    ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=True)
+
+    assert url == ub.create_url("image.jpg")
+
+
+def test_include_library_param_false():
     url = 'https://assets.imgix.net/image.jpg'
-    ub = imgix.UrlBuilder('assets.imgix.net', include_library_param=False)
+    ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=False)
 
     assert url == ub.create_url("image.jpg")

--- a/tests/test_url_helper.py
+++ b/tests/test_url_helper.py
@@ -18,7 +18,7 @@ def test_create():
 
 def test_create_with_url_parameters():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       sign_with_library_version=False,
+                       include_library_param=False,
                        params={"w": 400, "h": 300})
     assert str(helper) == "https://my-social-network.imgix.net/users/1.png?" \
                           "h=300&w=400"
@@ -26,7 +26,7 @@ def test_create_with_url_parameters():
 
 def test_create_with_splatted_falsy_parameter():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       sign_with_library_version=False,
+                       include_library_param=False,
                        params={"or": 0})
     assert str(helper) == "https://my-social-network.imgix.net" \
                           "/users/1.png?or=0"
@@ -35,7 +35,7 @@ def test_create_with_splatted_falsy_parameter():
 def test_create_with_signature():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        sign_key="FOO123bar",
-                       sign_with_library_version=False)
+                       include_library_param=False)
     assert str(helper) == \
         "https://my-social-network.imgix.net/users/1.png" \
         "?s=6797c24146142d5b40bde3141fd3600c"
@@ -44,7 +44,7 @@ def test_create_with_signature():
 def test_create_with_paremeters_and_signature():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        sign_key="FOO123bar",
-                       sign_with_library_version=False,
+                       include_library_param=False,
                        params={"w": 400, "h": 300})
     assert str(helper) == \
         "https://my-social-network.imgix.net/users/1.png" \
@@ -55,7 +55,7 @@ def test_create_with_fully_qualified_url():
     helper = UrlHelper("my-social-network.imgix.net",
                        "http://avatars.com/john-smith.png",
                        sign_key="FOO123bar",
-                       sign_with_library_version=False)
+                       include_library_param=False)
     assert str(helper) == \
         "https://my-social-network.imgix.net/"\
         "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
@@ -66,7 +66,7 @@ def test_create_with_fully_qualified_url_with_special_chars():
     helper = UrlHelper("my-social-network.imgix.net",
                        u"http://avatars.com/でのパ.png",
                        sign_key="FOO123bar",
-                       sign_with_library_version=False)
+                       include_library_param=False)
     assert str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F" \
                           "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png" \
                           "?s=8e04a5dd9a659a6a540d7c817d3df1d3"
@@ -84,14 +84,14 @@ def test_use_https():
 
 def test_utf_8_characters():
     helper = UrlHelper('my-social-network.imgix.net', u'/ǝ',
-                       sign_with_library_version=False)
+                       include_library_param=False)
     assert str(helper) == "https://my-social-network.imgix.net/%C7%9D"
 
 
 def test_more_involved_utf_8_characters():
     helper = UrlHelper('my-social-network.imgix.net',
                        u'/üsers/1/でのパ.png',
-                       sign_with_library_version=False)
+                       include_library_param=False)
     assert str(helper) == 'https://my-social-network.imgix.net/' \
                           '%C3%BCsers/1/%E3%81%A7%E3%81%AE%E3%83%91.png'
 
@@ -99,7 +99,7 @@ def test_more_involved_utf_8_characters():
 def test_param_values_are_escaped():
     helper = UrlHelper('my-social-network.imgix.net', 'demo.png',
                        params={"hello world": "interesting"},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     assert str(helper) == "https://my-social-network.imgix.net/demo.png?" \
                           "hello%20world=interesting"
@@ -109,7 +109,7 @@ def test_param_keys_are_escaped():
     params = {"hello_world": "/foo\"> <script>alert(\"hacked\")</script><"}
     helper = UrlHelper('my-social-network.imgix.net', 'demo.png',
                        params=params,
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     assert str(helper) == "https://my-social-network.imgix.net/demo.png?" \
         "hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22" \
@@ -120,7 +120,7 @@ def test_base64_param_variants_are_base64_encoded():
     params = {"txt64": u"I cannøt belîév∑ it wors! 😱"}
     helper = UrlHelper('my-social-network.imgix.net', '~text',
                        params=params,
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     assert str(helper) == "https://my-social-network.imgix.net/~text?txt64=" \
         "SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
@@ -130,7 +130,7 @@ def test_create_with_opts_kwarg():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                           sign_with_library_version=False,
+                           include_library_param=False,
                            opts={"w": 400, "h": 300})
         assert str(helper) == "https://my-social-network.imgix.net" \
                               "/users/1.png?h=300&w=400"
@@ -143,7 +143,7 @@ def test_create_url_with_opts_params_kwarg():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                           sign_with_library_version=False,
+                           include_library_param=False,
                            opts={"w": 500, "h": 400},
                            params={"w": 400, "h": 300},
                            )
@@ -163,7 +163,7 @@ def test_signing_url_with_ixlib():
 
 def test_set_parameter():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.set_parameter('w', 400)
     assert str(helper) == "https://my-social-network.imgix.net/" \
@@ -177,7 +177,7 @@ def test_set_parameter():
 def test_set_parameter_with_init_params():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        params={"or": 0},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.set_parameter('w', 400)
     helper.set_parameter('h', 300)
@@ -187,7 +187,7 @@ def test_set_parameter_with_init_params():
 
 def test_set_parameter_base64_encoded():
     helper = UrlHelper('my-social-network.imgix.net', '~text',
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.set_parameter("txt64", u"I cannøt belîév∑ it wors! 😱")
     assert str(helper) == "https://my-social-network.imgix.net/~text?txt64=" \
@@ -197,7 +197,7 @@ def test_set_parameter_base64_encoded():
 def test_set_parameter_with_none_value():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        params={'h': 300, 'w': 400},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.set_parameter("w", None)
     assert str(helper) == "https://my-social-network.imgix.net" \
@@ -207,7 +207,7 @@ def test_set_parameter_with_none_value():
 def test_set_parameter_with_false_value():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        params={'h': 300, 'w': 400},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.set_parameter("w", False)
     assert str(helper) == "https://my-social-network.imgix.net" \
@@ -217,7 +217,7 @@ def test_set_parameter_with_false_value():
 def test_delete_parameter():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        params={'h': 300, 'w': 400},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.delete_parameter('w')
     assert str(helper) == "https://my-social-network.imgix.net" \
@@ -227,7 +227,7 @@ def test_delete_parameter():
 def test_delete_all_parameters():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
                        params={'h': 300, 'w': 400},
-                       sign_with_library_version=False)
+                       include_library_param=False)
 
     helper.delete_parameter('w')
     helper.delete_parameter('h')


### PR DESCRIPTION
Renames the parameter used during `UrlBuilder` initialization for signing with the library name and version. Any attempt to pass in the previous parameter (`sign_with_library_version`) will raise a deprecation warning.
