### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ provide your signature key to the URL builder.
 Domain Sharded URLs
 -------------------
 
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**
 Domain sharding enables you to spread image requests across multiple domains.
 This allows you to bypass the requests-per-host limits of browsers. We
 recommend 2-3 domain shards maximum if you are going to use domain sharding.

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -33,6 +33,9 @@ class UrlBuilder(object):
         ensure image path always resolves to the same domain. If
         `SHARD_STRATEGY_CYCLE`, domain sharding performed by sequentially
         cycling through the domains list.  (default `SHARD_STRATEGY_CRC`)
+
+        Note: domain sharding is deprecated and will be removed in next major
+        version
     sign_with_library_version : bool
         Deprecated and to be removed in next major version
     include_library_param : bool
@@ -57,6 +60,11 @@ class UrlBuilder(object):
             warnings.warn('`sign_with_library_version` has been deprecated ' +
                           'and will be removed in the next major version. ' +
                           'Use `include_library_param` instead.',
+                          DeprecationWarning, stacklevel=2)
+
+        if isinstance(domains, (list, tuple)) and (len(domains) > 1):
+            warnings.warn('Domain sharding has been deprecated and will ' +
+                          'be removed in the next major version. ',
                           DeprecationWarning, stacklevel=2)
 
         if not isinstance(domains, (list, tuple)):

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -25,28 +25,6 @@ def test_create():
     assert type(builder) is imgix.UrlBuilder
 
 
-def test_create_accepts_domains_list():
-    domains = [
-        'my-social-network-1.imgix.net',
-        'my-social-network-2.imgix.net'
-    ]
-    builder = imgix.UrlBuilder(domains,
-                               shard_strategy=imgix.SHARD_STRATEGY_CRC)
-    assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
-
-
-def test_create_accepts_domains_tuple():
-    domains = (
-        'my-social-network-1.imgix.net',
-        'my-social-network-2.imgix.net'
-    )
-    builder = imgix.UrlBuilder(domains,
-                               shard_strategy=imgix.SHARD_STRATEGY_CRC)
-    assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
-
-
 def test_create_accepts_domains_single_str():
     domain = 'my-social-network-1.imgix.net'
     builder = imgix.UrlBuilder(domain)
@@ -216,22 +194,6 @@ def test_signing_url_with_ixlib():
         imgix._version.__version__)
 
 
-def test_shard_strategy_crc():
-    domains = (
-        'my-social-network-1.imgix.net',
-        'my-social-network-2.imgix.net'
-    )
-    builder = imgix.UrlBuilder(domains,
-                               shard_strategy=imgix.SHARD_STRATEGY_CRC)
-    assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[0] == _get_domain(builder.create_url('/users/2.png'))
-    assert domains[0] == _get_domain(builder.create_url('/users/2.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/b.png'))
-
-
 def test_shard_strategy_crc_single_domain():
     domain = 'my-social-network-1.imgix.net'
 
@@ -240,22 +202,6 @@ def test_shard_strategy_crc_single_domain():
     assert domain == _get_domain(builder.create_url('/users/1.png'))
     assert domain == _get_domain(builder.create_url('/users/2.png'))
     assert domain == _get_domain(builder.create_url('/users/2.png'))
-
-
-def test_shard_strategy_cycle():
-    domains = (
-        'my-social-network-1.imgix.net',
-        'my-social-network-2.imgix.net',
-        'my-social-network-3.imgix.net',
-    )
-    builder = imgix.UrlBuilder(domains,
-                               shard_strategy=imgix.SHARD_STRATEGY_CYCLE)
-    assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[2] == _get_domain(builder.create_url('/users/1.png'))
-    assert domains[0] == _get_domain(builder.create_url('/users/a.png'))
-    assert domains[1] == _get_domain(builder.create_url('/users/b.png'))
-    assert domains[2] == _get_domain(builder.create_url('/users/c.png'))
 
 
 def test_shard_strategy_cycle_single_domain():
@@ -354,3 +300,77 @@ def test_include_library_param_false():
     ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=False)
 
     assert url == ub.create_url("image.jpg")
+
+
+def test_throw_warning_with_domains_list():
+    domains = [
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net'
+    ]
+
+    with warnings.catch_warnings(record=True) as w:
+        builder = imgix.UrlBuilder(domains,
+                                   shard_strategy=imgix.SHARD_STRATEGY_CRC)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
+
+
+def test_throw_warning_with_domains_tuple():
+    domains = (
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net'
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        builder = imgix.UrlBuilder(domains,
+                                   shard_strategy=imgix.SHARD_STRATEGY_CRC)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
+
+
+def test_deprecate_shard_strategy_crc():
+    domains = (
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net'
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        builder = imgix.UrlBuilder(domains,
+                                   shard_strategy=imgix.SHARD_STRATEGY_CRC)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[0] == _get_domain(builder.create_url('/users/2.png'))
+        assert domains[0] == _get_domain(builder.create_url('/users/2.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/a.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/b.png'))
+
+
+def test_deprecate_shard_strategy_cycle():
+    domains = (
+        'my-social-network-1.imgix.net',
+        'my-social-network-2.imgix.net',
+        'my-social-network-3.imgix.net',
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        builder = imgix.UrlBuilder(domains,
+                                   shard_strategy=imgix.SHARD_STRATEGY_CYCLE)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert domains[0] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[2] == _get_domain(builder.create_url('/users/1.png'))
+        assert domains[0] == _get_domain(builder.create_url('/users/a.png'))
+        assert domains[1] == _get_domain(builder.create_url('/users/b.png'))
+        assert domains[2] == _get_domain(builder.create_url('/users/c.png'))


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-python library.
The `UrlBuilder` object will now throw a warning when users attempt to initialize it by passing in multiple domains in the form of a list or tuple.