### PR TITLE
docs: add link to domain sharding deprecation blog post

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,9 @@ provide your signature key to the URL builder.
 Domain Sharded URLs
 -------------------
 
-**Warning: Domain Sharding has been deprecated and will be removed in the next major release**
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
+To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
+
 Domain sharding enables you to spread image requests across multiple domains.
 This allows you to bypass the requests-per-host limits of browsers. We
 recommend 2-3 domain shards maximum if you are going to use domain sharding.


### PR DESCRIPTION
This PR adds a link in the README to the [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding), explaining the decision to remove the domain sharding feature from the imgix SDK.

Relates to #41 