### PR TITLE
 format: correct malformed hyperlink is rst 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,11 @@ Domain Sharded URLs
 -------------------
 
 **Warning: Domain Sharding has been deprecated and will be removed in the next major release**
+
+To find out more, see our `blog post`_ explaining the decision to remove this feature.
+
+.. _blog post: https://blog.imgix.com/2019/05/03/deprecating-domain-sharding
+
 Domain sharding enables you to spread image requests across multiple domains.
 This allows you to bypass the requests-per-host limits of browsers. We
 recommend 2-3 domain shards maximum if you are going to use domain sharding.


### PR DESCRIPTION
This PR corrects a malformed rst hyperlink in #42 

Relates to #41