### PR TITLE
feat: deprecate `domains` in favor of `domain`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ provide your signature key to the URL builder.
 Domain Sharded URLs
 -------------------
 
-**Warning: Domain Sharding has been deprecated and will be removed in the next major release**
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release. As a result, the** ``domains`` **argument will be deprecated in favor of** ``domain`` **instead.**
 
 To find out more, see our `blog post`_ explaining the decision to remove this feature.
 

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -49,12 +49,13 @@ class UrlBuilder(object):
     """
     def __init__(
             self,
-            domains,
+            domains=None,
             use_https=True,
             sign_key=None,
             shard_strategy=SHARD_STRATEGY_CRC,
             sign_with_library_version=None,
-            include_library_param=True):
+            include_library_param=True,
+            domain=None):
 
         if sign_with_library_version is not None:
             warnings.warn('`sign_with_library_version` has been deprecated ' +
@@ -62,13 +63,23 @@ class UrlBuilder(object):
                           'Use `include_library_param` instead.',
                           DeprecationWarning, stacklevel=2)
 
-        if isinstance(domains, (list, tuple)) and (len(domains) > 1):
-            warnings.warn('Domain sharding has been deprecated and will ' +
-                          'be removed in the next major version. ',
-                          DeprecationWarning, stacklevel=2)
-
-        if not isinstance(domains, (list, tuple)):
-            domains = [domains]
+        if isinstance(domains, (list, tuple)):
+            if (len(domains) > 1):
+                warnings.warn('Domain sharding has been deprecated and will ' +
+                              'be removed in the next major version.\nAs a ' +
+                              'result, the \'domains\' argument will be ' +
+                              'deprecated in favor of \'domain\' instead.',
+                              DeprecationWarning, stacklevel=2)
+            elif (len(domains) == 0):
+                raise ValueError('Domains cannot take an empty array')
+        else:
+            if isinstance(domains, str):
+                domains = [domains]
+            elif isinstance(domain, str):
+                domains = [domain]
+            else:
+                raise ValueError('UrlBuilder must be passed a valid ' +
+                                 'string domain')
 
         self.validate_domain(domains)
         include_library_param = (

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -374,3 +374,42 @@ def test_deprecate_shard_strategy_cycle():
         assert domains[0] == _get_domain(builder.create_url('/users/a.png'))
         assert domains[1] == _get_domain(builder.create_url('/users/b.png'))
         assert domains[2] == _get_domain(builder.create_url('/users/c.png'))
+
+
+def test_domains_is_prioritized_over_domain():
+    url = ('https://my-social-network-2.imgix.net/image.jpg?ixlib=python-'
+           + imgix.__version__)
+
+    with warnings.catch_warnings(record=True) as w:
+        ub = imgix.UrlBuilder(domains=['my-social-network-1.imgix.net',
+                                       'my-social-network-2.imgix.net'],
+                              domain='different-network.imgix.net')
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
+        assert url == ub.create_url('image.jpg')
+
+
+def test_domain_accepts_string():
+    url = ('https://my-social-network.imgix.net/image.jpg?ixlib=python-'
+           + imgix.__version__)
+    ub = imgix.UrlBuilder(domain='my-social-network.imgix.net')
+    assert url == ub.create_url('image.jpg')
+
+
+def test_error_on_nonstring_domain():
+    try:
+        imgix.UrlBuilder(domain=['my-social-network.imgix.net'])
+    except ValueError:
+        pass
+    else:
+        assert(False)
+
+
+def test_error_on_no_domain():
+    try:
+        imgix.UrlBuilder()
+    except ValueError:
+        pass
+    else:
+        assert(False)


### PR DESCRIPTION
This PR adds a new parameter/field `domain` to `UrlBuilder`, as part of the transition to remove domain sharding (and with it, `domains`).