### PR TITLE
feat: add srcset generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,23 +84,23 @@ Will produce the following attribute value, which can then be served to the clie
     https://demos.imgix.net/image.png?w=7400&s=ad671301ed4663c3ce6e84cb646acb96 7400w,
     https://demos.imgix.net/image.png?w=8192&s=a0fed46e2bbcc70ded13dc629aee5398 8192w
 
-In cases where enough information is provided about an image's dimensions, create_srcset() will instead build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are 'w', 'h', and 'ar'. By invoking create_srcset() with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+In cases where enough information is provided about an image's dimensions, create_srcset() will instead build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are 'w', 'h', and 'ar'. By invoking create_srcset() with either a width **or** the height and aspect ratio (along with fit=crop, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 .. code-block:: python
 
     builder = imgix.UrlBuilder("demos.imgix.net", sign_key='my-token', include_library_param=False)
-    srcset = builder.create_srcset('image.png', {'h':800,'ar':'3:2'})
+    srcset = builder.create_srcset('image.png', {'h':800, 'ar':'3:2', 'fit':'crop'})
     print srcset
 
 Will produce the following attribute value:
 
 .. code-block:: html
 
-    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 1x,
-    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 2x,
-    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 3x,
-    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 4x,
-    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 5x
+    https://demos.imgix.net/image.png?ar=3%3A2&fit=crop&h=800&s=333a2140375016c2a6d2cf53e189ed90 1x,
+    https://demos.imgix.net/image.png?ar=3%3A2&fit=crop&h=800&s=333a2140375016c2a6d2cf53e189ed90 2x,
+    https://demos.imgix.net/image.png?ar=3%3A2&fit=crop&h=800&s=333a2140375016c2a6d2cf53e189ed90 3x,
+    https://demos.imgix.net/image.png?ar=3%3A2&fit=crop&h=800&s=333a2140375016c2a6d2cf53e189ed90 4x,
+    https://demos.imgix.net/image.png?ar=3%3A2&fit=crop&h=800&s=333a2140375016c2a6d2cf53e189ed90 5x
 
 For more information to better understand srcset, we highly recommend `Eric Portis' "Srcset and sizes" article <https://ericportis.com/posts/2014/srcset-sizes/>`_ which goes into depth about the subject.
 

--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,12 @@ provide your signature key to the URL builder.
 Srcset Generation
 -----------------
 
-The imgix-python package allows for generation of custom srcset attributes, which can be invoked through create_srcset(). By default, the srcset generated will allow for responsive size switching by building a list of image-width mappings.
+The imgix-python package allows for generation of custom srcset attributes, which can be invoked through :code:`create_srcset()`. By default, the srcset generated will allow for responsive size switching by building a list of image-width mappings.
 
 .. code-block:: python
 
-    builder = imgix.UrlBuilder("demos.imgix.net", sign_key='my-token', include_library_param=False)
-    srcset = builder.create_srcset('image.png')
+    builder = imgix.UrlBuilder("demos.imgix.net", sign_key="my-token", include_library_param=False)
+    srcset = builder.create_srcset("image.png")
     print srcset
 
 Will produce the following attribute value, which can then be served to the client:
@@ -84,12 +84,12 @@ Will produce the following attribute value, which can then be served to the clie
     https://demos.imgix.net/image.png?w=7400&s=ad671301ed4663c3ce6e84cb646acb96 7400w,
     https://demos.imgix.net/image.png?w=8192&s=a0fed46e2bbcc70ded13dc629aee5398 8192w
 
-In cases where enough information is provided about an image's dimensions, create_srcset() will instead build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are 'w', 'h', and 'ar'. By invoking create_srcset() with either a width **or** the height and aspect ratio (along with fit=crop, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+In cases where enough information is provided about an image's dimensions, :code:`create_srcset()` will instead build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are :code:`w`, :code:`h`, and :code:`ar`. By invoking :code:`create_srcset()` with either a width **or** the height and aspect ratio (along with fit=crop, typically) provided, a different srcset will be generated for a fixed-size image instead.
 
 .. code-block:: python
 
-    builder = imgix.UrlBuilder("demos.imgix.net", sign_key='my-token', include_library_param=False)
-    srcset = builder.create_srcset('image.png', {'h':800, 'ar':'3:2', 'fit':'crop'})
+    builder = imgix.UrlBuilder("demos.imgix.net", sign_key="my-token", include_library_param=False)
+    srcset = builder.create_srcset("image.png", {'h':800, 'ar':'3:2', 'fit':'crop'})
     print srcset
 
 Will produce the following attribute value:

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,48 @@ provide your signature key to the URL builder.
     # Prints out:
     # http://demos.imgix.net/bridge.png?h=100&w=100&s=7370d6e36bb2262e73b19578739af1af
 
+Srcset Generation
+-----------------
+
+The imgix-python package allows for generation of custom srcset attributes, which can be invoked through create_srcset(). By default, the srcset generated will allow for responsive size switching by building a list of image-width mappings.
+
+.. code-block:: python
+
+    builder = imgix.UrlBuilder("demos.imgix.net", sign_key='my-token', include_library_param=False)
+    srcset = builder.create_srcset('image.png')
+    print srcset
+
+Will produce the following attribute value, which can then be served to the client:
+
+.. code-block:: html
+
+    https://demos.imgix.net/image.png?w=100&s=e415797545a77a9d2842dedcfe539c9a 100w,
+    https://demos.imgix.net/image.png?w=116&s=b2da46f5c23ef13d5da30f0a4545f33f 116w,
+    https://demos.imgix.net/image.png?w=134&s=b61422dead929f893c04b8ff839bb088 134w,
+                                            ...
+    https://demos.imgix.net/image.png?w=7400&s=ad671301ed4663c3ce6e84cb646acb96 7400w,
+    https://demos.imgix.net/image.png?w=8192&s=a0fed46e2bbcc70ded13dc629aee5398 8192w
+
+In cases where enough information is provided about an image's dimensions, create_srcset() will instead build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are 'w', 'h', and 'ar'. By invoking create_srcset() with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+
+.. code-block:: python
+
+    builder = imgix.UrlBuilder("demos.imgix.net", sign_key='my-token', include_library_param=False)
+    srcset = builder.create_srcset('image.png', {'h':800,'ar':'3:2'})
+    print srcset
+
+Will produce the following attribute value:
+
+.. code-block:: html
+
+    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 1x,
+    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 2x,
+    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 3x,
+    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 4x,
+    https://demos.imgix.net/image.png?ar=3%3A2&h=800&s=da77456b3444ff2199a6cb27966a972a 5x
+
+For more information to better understand srcset, we highly recommend `Eric Portis' "Srcset and sizes" article <https://ericportis.com/posts/2014/srcset-sizes/>`_ which goes into depth about the subject.
+
 Usage with UTF-8
 ----------------
 

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -5,20 +5,3 @@ DOMAIN_PATTERN = re.compile(
             r'(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)'
             r'[a-z\d]{1,63}$'
         )
-
-
-def target_widths():
-    resolutions = []
-    prev = 100
-    INCREMENT_PERCENTAGE = 8
-    MAX_SIZE = 8192
-
-    def ensureEven(n):
-        return 2 * round(n/2)
-
-    while prev <= MAX_SIZE:
-        resolutions.append(ensureEven(prev))
-        prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2
-
-    resolutions.append(MAX_SIZE)
-    return resolutions

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -5,3 +5,20 @@ DOMAIN_PATTERN = re.compile(
             r'(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)'
             r'[a-z\d]{1,63}$'
         )
+
+
+def target_widths():
+    resolutions = []
+    prev = 100
+    INCREMENT_PERCENTAGE = 8
+    MAX_SIZE = 8192
+
+    def ensureEven(n):
+        return 2 * round(n/2)
+
+    while prev <= MAX_SIZE:
+        resolutions.append(ensureEven(prev))
+        prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2
+
+    resolutions.append(MAX_SIZE)
+    return resolutions

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -4,7 +4,11 @@ import re
 
 from .urlhelper import UrlHelper
 
-from .constants import DOMAIN_PATTERN, target_widths
+from .constants import DOMAIN_PATTERN
+
+
+SRCSET_INCREMENT_PERCENTAGE = 8
+SRCSET_MAX_SIZE = 8192
 
 
 class UrlBuilder(object):
@@ -143,10 +147,28 @@ class UrlBuilder(object):
         else:
             return self._build_srcset_pairs(path, params)
 
-    def _build_srcset_pairs(self, path, params={}):
+    def _target_widths(self):
+        resolutions = []
+        prev = 100
+
+        def ensureEven(n):
+            return 2 * round(n/2)
+
+        while prev <= SRCSET_MAX_SIZE:
+            resolutions.append(prev)
+            print(prev)
+            prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100.0) * 2
+            prev = int(ensureEven(prev))
+
+        resolutions.append(SRCSET_MAX_SIZE)
+        return resolutions
+
+    def _build_srcset_pairs(self, path, params=None):
+        if not params:
+            params = {}
         srcset = ''
-        # widths = target_widths()
-        widths = [100, 116, 134, 156, 182, 210, 244, 282, 328, 380, 442, 512, 594, 688, 798, 926, 1074, 1246, 1446, 1678, 1946, 2258, 2618, 3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
+        widths = self._target_widths()
+
         for i in range(len(widths)):
             current_width = widths[i]
             current_params = params

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -151,14 +151,12 @@ class UrlBuilder(object):
         resolutions = []
         prev = 100
 
-        def ensureEven(n):
-            return 2 * round(n/2)
+        def ensure_even(n):
+            return 2 * round(n/2.0)
 
         while prev <= SRCSET_MAX_SIZE:
-            resolutions.append(prev)
-            print(prev)
+            resolutions.append(int(ensure_even(prev)))
             prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100.0) * 2
-            prev = int(ensureEven(prev))
 
         resolutions.append(SRCSET_MAX_SIZE)
         return resolutions

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -90,9 +90,9 @@ class UrlBuilder(object):
         return str(url_obj)
 
     def create_srcset(self, path, params={}):
-        width = params['w']
-        height = params['h']
-        aspect_ratio = params['ar']
+        width = params['w'] if 'w' in params else None
+        height = params['h'] if 'h' in params else None
+        aspect_ratio = params['ar'] if 'ar' in params else None
 
         if (width or (height and aspect_ratio)):
             return self.__build_srcset_DPR(path, params)
@@ -105,10 +105,10 @@ class UrlBuilder(object):
 
         for i in range(len(widths)):
             current_width = widths[i]
-            current_params = params
+            current_params = params.copy()
             current_params['w'] = current_width
-            srcset += self.create_url(path, current_params)
-            + ' ' + str(current_width) + 'w,\n'
+            srcset += str(f'{self.create_url(path, current_params)} ' +
+                          f'{current_width}w,\n')
 
         return srcset[0:-2]
 
@@ -119,6 +119,6 @@ class UrlBuilder(object):
 
         for i in range(len(target_ratios)):
             current_ratio = target_ratios[i]
-            srcset += url + ' ' + str(current_ratio) + 'x,\n'
+            srcset += f'{url} {str(current_ratio)}x,\n'
 
         return srcset[0:-2]

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -30,8 +30,17 @@ class UrlBuilder(object):
 
     Methods
     -------
+    validate_domain(domain)
+        Returns true if the supplied string parameter pattern matches a valid
+        domain name accepted by imgix
     create_url(path, params={})
         Create URL with the supplied path and `params` parameters dict.
+    create_srcset(path, params={})
+        Create srcset attribute value with the supplied path and
+        `params` parameters dict.
+        Will generate a fixed-width DPR srcset if a width OR height and aspect
+        ratio are passed in as parameters. Otherwise will generate a srcset
+        with width-descriptor pairs.
     """
     def __init__(
             self,
@@ -48,6 +57,19 @@ class UrlBuilder(object):
         self._include_library_param = include_library_param
 
     def validate_domain(self, domain):
+        """
+        Returns true if the supplied string parameter pattern matches a valid
+        domain name accepted by imgix
+
+        Parameters
+        ----------
+        domain : str
+
+        Returns
+        -------
+        bool
+        """
+
         err_str = str(
             'Domain must be passed in as fully-qualified domain names and ' +
             'should not include a protocol or any path element, i.e. ' +
@@ -90,6 +112,28 @@ class UrlBuilder(object):
         return str(url_obj)
 
     def create_srcset(self, path, params={}):
+        """
+        Create srcset attribute value with the supplied path and
+        `params` parameters dict.
+        Will generate a fixed-width DPR srcset if a width OR height and aspect
+        ratio are passed in as parameters. Otherwise will generate a srcset
+        with width-descriptor pairs.
+
+        Parameters
+        ----------
+        path : str
+        params : dict
+            Dictionary specifying URL parameters. Non-imgix parameters are
+            added to the URL unprocessed. For a complete list of imgix
+            supported parameters, visit https://docs.imgix.com/apis/url .
+            (default {})
+
+        Returns
+        -------
+        str
+            srcset attribute value
+        """
+
         width = params['w'] if 'w' in params else None
         height = params['h'] if 'h' in params else None
         aspect_ratio = params['ar'] if 'ar' in params else None

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -107,8 +107,8 @@ class UrlBuilder(object):
             current_width = widths[i]
             current_params = params.copy()
             current_params['w'] = current_width
-            srcset += str(f'{self.create_url(path, current_params)} ' +
-                          f'{current_width}w,\n')
+            srcset += self.create_url(path, current_params) \
+                + ' ' + str(current_width) + 'w,\n'
 
         return srcset[0:-2]
 
@@ -119,6 +119,6 @@ class UrlBuilder(object):
 
         for i in range(len(target_ratios)):
             current_ratio = target_ratios[i]
-            srcset += f'{url} {str(current_ratio)}x,\n'
+            srcset += url + ' ' + str(current_ratio) + 'x,\n'
 
         return srcset[0:-2]

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -4,7 +4,7 @@ import re
 
 from .urlhelper import UrlHelper
 
-from .constants import DOMAIN_PATTERN
+from .constants import DOMAIN_PATTERN, target_widths
 
 
 class UrlBuilder(object):
@@ -88,3 +88,37 @@ class UrlBuilder(object):
             params=params)
 
         return str(url_obj)
+
+    def create_srcset(self, path, params={}):
+        width = params['w']
+        height = params['h']
+        aspect_ratio = params['ar']
+
+        if (width or (height and aspect_ratio)):
+            return self.__build_srcset_DPR(path, params)
+        else:
+            return self.__build_srcset_pairs(path, params)
+
+    def __build_srcset_pairs(self, path, params={}):
+        srcset = ''
+        widths = target_widths()
+
+        for i in range(len(widths)):
+            current_width = widths[i]
+            current_params = params
+            current_params['w'] = current_width
+            srcset += self.create_url(path, current_params)
+            + ' ' + str(current_width) + 'w,\n'
+
+        return srcset[0:-2]
+
+    def __build_srcset_DPR(self, path, params={}):
+        srcset = ''
+        target_ratios = [1, 2, 3, 4, 5]
+        url = self.create_url(path, params)
+
+        for i in range(len(target_ratios)):
+            current_ratio = target_ratios[i]
+            srcset += url + ' ' + str(current_ratio) + 'x,\n'
+
+        return srcset[0:-2]

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -139,24 +139,23 @@ class UrlBuilder(object):
         aspect_ratio = params['ar'] if 'ar' in params else None
 
         if (width or (height and aspect_ratio)):
-            return self.__build_srcset_DPR(path, params)
+            return self._build_srcset_DPR(path, params)
         else:
-            return self.__build_srcset_pairs(path, params)
+            return self._build_srcset_pairs(path, params)
 
-    def __build_srcset_pairs(self, path, params={}):
+    def _build_srcset_pairs(self, path, params={}):
         srcset = ''
         widths = target_widths()
-
         for i in range(len(widths)):
             current_width = widths[i]
-            current_params = params.copy()
+            current_params = params
             current_params['w'] = current_width
             srcset += self.create_url(path, current_params) \
                 + ' ' + str(current_width) + 'w,\n'
 
         return srcset[0:-2]
 
-    def __build_srcset_DPR(self, path, params={}):
+    def _build_srcset_DPR(self, path, params={}):
         srcset = ''
         target_ratios = [1, 2, 3, 4, 5]
         url = self.create_url(path, params)

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -145,7 +145,8 @@ class UrlBuilder(object):
 
     def _build_srcset_pairs(self, path, params={}):
         srcset = ''
-        widths = target_widths()
+        # widths = target_widths()
+        widths = [100, 116, 134, 156, 182, 210, 244, 282, 328, 380, 442, 512, 594, 688, 798, 926, 1074, 1246, 1446, 1678, 1946, 2258, 2618, 3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
         for i in range(len(widths)):
             current_width = widths[i]
             current_params = params

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -176,7 +176,9 @@ class UrlBuilder(object):
 
         return srcset[0:-2]
 
-    def _build_srcset_DPR(self, path, params={}):
+    def _build_srcset_DPR(self, path, params=None):
+        if not params:
+            params = {}
         srcset = ''
         target_ratios = [1, 2, 3, 4, 5]
         url = self.create_url(path, params)

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -2,6 +2,7 @@
 
 import imgix
 import hashlib
+import re
 
 
 def _default_srcset(params={}):
@@ -19,6 +20,25 @@ def test_no_parameters_generates_srcset_pairs():
     srcset = _default_srcset()
     expected_number_of_pairs = 31
     assert(expected_number_of_pairs == len(srcset.split(',')))
+
+
+def test_srcset_pair_values():
+    # array of expected resolutions to be generated
+    resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                   328, 380, 442, 512, 594, 688, 798, 926,
+                   1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                   3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
+    srcset = _default_srcset()
+    srclist = srcset.split(',')
+    index = 0
+
+    for src in srclist:
+        width = src.split(' ')[1]
+
+        # extract width int values
+        value = re.search(re.compile(r'\d+'), width)
+        assert(int(value.group(0)) == resolutions[index])
+        index += 1
 
 
 def test_given_width_srcset_is_DPR():

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+
+import imgix
+import hashlib
+
+
+def _default_srcset(params={}):
+    ub = imgix.UrlBuilder('testing.imgix.net',
+                          sign_key='MYT0KEN',
+                          include_library_param=False)
+    return ub.create_srcset('image.jpg', params)
+
+
+def parse_width(width):
+    return int(width[0:-1])
+
+
+def test_no_parameters_generates_srcset_pairs():
+    srcset = _default_srcset()
+    expected_number_of_pairs = 31
+    assert(expected_number_of_pairs == len(srcset.split(',')))
+
+
+def test_given_width_srcset_is_DPR():
+    srcset = _default_srcset({'w': 100})
+    device_pixel_ratio = 1
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        ratio = src.split(' ')[1]
+        assert(f'{device_pixel_ratio}x' == ratio)
+        device_pixel_ratio += 1
+
+
+def test_given_width_signs_urls():
+    srcset = _default_srcset({'w': 100})
+    expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        url = src.split(' ')[0]
+        assert('s=' in url)
+
+        # extract the sign parameter
+        generated_signature = url[url.index('s=')+2:len(url)]
+        assert(expected_signature == generated_signature)
+
+
+def test_given_height_srcset_generates_pairs():
+    srcset = _default_srcset({'h': 100})
+    expected_number_of_pairs = 31
+    assert(expected_number_of_pairs == len(srcset.split(',')))
+
+
+def test_given_height_respects_parameter():
+    srcset = _default_srcset({'h': 100})
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        assert('h=100' in src)
+
+
+def test_given_height_srcset_pairs_within_bounds():
+    srcset = _default_srcset({'h': 100})
+    srclist = srcset.split(',')
+
+    min_parsed = srclist[0].split(' ')[1]
+    max_parsed = srclist[-1].split(' ')[1]
+    min = parse_width(min_parsed)
+    max = parse_width(max_parsed)
+
+    assert(min >= 100)
+    assert(max <= 8192)
+
+
+def test_given_height_srcset_iterates_18_percent():
+    increment_allowed = 0.18
+    srcset = _default_srcset({'h': 100})
+    srcslist = srcset.split(',')
+    widths_list = [src.split(' ')[1] for src in srcslist]
+    # a list of all widths as integers
+    widths = [parse_width(width) for width in widths_list]
+
+    prev = widths[0]
+    for i in range(1, len(widths)):
+        width = widths[i]
+        assert((width / prev) < (1 + increment_allowed))
+        prev = width
+
+
+def test_given_height_srcset_signs_urls():
+    srcset = _default_srcset({'h': 100})
+    srclist = srcset.split(',')
+    srcs = [src.split(' ')[0] for src in srclist]
+
+    for src in srcs:
+        assert(src.index('s='))
+        params = src[src.index('?'):len(src)]
+        params = params[0:params.index('s=')-1]
+        # extract the sign parameter
+        generated_signature = src[src.index('s=')+2:len(src)]
+
+        signature_base = 'MYT0KEN' + '/image.jpg' + params
+        expected_signature = hashlib.md5(signature_base
+                                         .encode('utf-8')).hexdigest()
+
+        assert(expected_signature == generated_signature)
+
+
+def test_given_width_and_height_DPR():
+    srcset = _default_srcset({'w': 100, 'h': 100})
+    device_pixel_ratio = 1
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        ratio = src.split(' ')[1]
+        assert(f'{device_pixel_ratio}x' == ratio)
+        device_pixel_ratio += 1
+
+
+def test_given_width_and_height_signs_urls():
+    srcset = _default_srcset({'w': 100, 'h': 100})
+    expected_signature = '1bd495fdddc25957838a8f844b84d3a3'
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        url = src.split(' ')[0]
+        assert('s=' in url)
+
+        # extract the sign parameter
+        generated_signature = url[url.index('s=')+2:len(url)]
+        assert(expected_signature == generated_signature)
+
+
+def test_given_aspect_ratio_srcset_generates_pairs():
+    srcset = _default_srcset({'ar': '3:2'})
+    expected_number_of_pairs = 31
+    assert(expected_number_of_pairs == len(srcset.split(',')))
+
+
+def test_given_aspect_ratio_srcset_pairs_within_bounds():
+    srcset = _default_srcset({'ar': '3:2'})
+    srclist = srcset.split(',')
+
+    min_parsed = srclist[0].split(' ')[1]
+    max_parsed = srclist[-1].split(' ')[1]
+    min = parse_width(min_parsed)
+    max = parse_width(max_parsed)
+
+    assert(min >= 100)
+    assert(max <= 8192)
+
+
+def test_given_aspect_ratio_srcset_iterates_18_percent():
+    increment_allowed = 0.18
+    srcset = _default_srcset({'ar': '3:2'})
+    srcslist = srcset.split(',')
+    widths_list = [src.split(' ')[1] for src in srcslist]
+    # a list of all widths as int
+    widths = [parse_width(width) for width in widths_list]
+
+    prev = widths[0]
+    for i in range(1, len(widths)):
+        width = widths[i]
+        assert((width / prev) < (1 + increment_allowed))
+        prev = width
+
+
+def test_given_aspect_ratio_srcset_signs_urls():
+    srcset = _default_srcset({'ar': '3:2'})
+    srclist = srcset.split(',')
+    srcs = [src.split(' ')[0] for src in srclist]
+
+    for src in srcs:
+        assert(src.index('s='))
+        params = src[src.index('?'):len(src)]
+        params = params[0:params.index('s=')-1]
+        # extract the sign parameter
+        generated_signature = src[src.index('s=')+2:len(src)]
+
+        signature_base = 'MYT0KEN' + '/image.jpg' + params
+        expected_signature = hashlib.md5(signature_base
+                                         .encode('utf-8')).hexdigest()
+
+        assert(expected_signature == generated_signature)
+
+
+def test_given_aspect_ratio_and_height_srcset_is_DPR():
+    srcset = _default_srcset({'w': 100})
+    device_pixel_ratio = 1
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        ratio = src.split(' ')[1]
+        assert(f'{device_pixel_ratio}x' == ratio)
+        device_pixel_ratio += 1
+
+
+def test_given_ratio_and_height_srcset_signs_urls():
+    srcset = _default_srcset({'w': 100})
+    expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+    srclist = srcset.split(',')
+
+    for src in srclist:
+        url = src.split(' ')[0]
+        assert('s=' in url)
+
+        # extract the sign parameter
+        generated_signature = url[url.index('s=')+2:len(url)]
+        assert(expected_signature == generated_signature)

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -28,7 +28,8 @@ def test_given_width_srcset_is_DPR():
 
     for src in srclist:
         ratio = src.split(' ')[1]
-        assert(f'{device_pixel_ratio}x' == ratio)
+        dpr_str = str(device_pixel_ratio) + 'x'
+        assert(dpr_str == ratio)
         device_pixel_ratio += 1
 
 
@@ -114,7 +115,8 @@ def test_given_width_and_height_DPR():
 
     for src in srclist:
         ratio = src.split(' ')[1]
-        assert(f'{device_pixel_ratio}x' == ratio)
+        dpr_str = str(device_pixel_ratio) + 'x'
+        assert(dpr_str == ratio)
         device_pixel_ratio += 1
 
 
@@ -192,7 +194,8 @@ def test_given_aspect_ratio_and_height_srcset_is_DPR():
 
     for src in srclist:
         ratio = src.split(' ')[1]
-        assert(f'{device_pixel_ratio}x' == ratio)
+        dpr_str = str(device_pixel_ratio) + 'x'
+        assert(dpr_str == ratio)
         device_pixel_ratio += 1
 
 

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -11,7 +11,7 @@ def _default_srcset(params={}):
     return ub.create_srcset('image.jpg', params)
 
 
-def parse_width(width):
+def _parse_width(width):
     return int(width[0:-1])
 
 
@@ -67,8 +67,8 @@ def test_given_height_srcset_pairs_within_bounds():
 
     min_parsed = srclist[0].split(' ')[1]
     max_parsed = srclist[-1].split(' ')[1]
-    min = parse_width(min_parsed)
-    max = parse_width(max_parsed)
+    min = _parse_width(min_parsed)
+    max = _parse_width(max_parsed)
 
     assert(min >= 100)
     assert(max <= 8192)
@@ -80,7 +80,7 @@ def test_given_height_srcset_iterates_18_percent():
     srcslist = srcset.split(',')
     widths_list = [src.split(' ')[1] for src in srcslist]
     # a list of all widths as integers
-    widths = [parse_width(width) for width in widths_list]
+    widths = [_parse_width(width) for width in widths_list]
 
     prev = widths[0]
     for i in range(1, len(widths)):
@@ -146,8 +146,8 @@ def test_given_aspect_ratio_srcset_pairs_within_bounds():
 
     min_parsed = srclist[0].split(' ')[1]
     max_parsed = srclist[-1].split(' ')[1]
-    min = parse_width(min_parsed)
-    max = parse_width(max_parsed)
+    min = _parse_width(min_parsed)
+    max = _parse_width(max_parsed)
 
     assert(min >= 100)
     assert(max <= 8192)
@@ -159,7 +159,7 @@ def test_given_aspect_ratio_srcset_iterates_18_percent():
     srcslist = srcset.split(',')
     widths_list = [src.split(' ')[1] for src in srcslist]
     # a list of all widths as int
-    widths = [parse_width(width) for width in widths_list]
+    widths = [_parse_width(width) for width in widths_list]
 
     prev = widths[0]
     for i in range(1, len(widths)):


### PR DESCRIPTION
This PR adds a new function to the imgix-python interface that will either generate a width descriptor or DPR `srcset` based on the specified parameters.
Also corrects how the `params` argument is initialized in `create_url()` to prevent potential bizarre behavior.