### PR TITLE
build(tox): improve code coverage reporting; parallelize testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,11 @@
 [run]
+source =
+    imgix/
+    tests/
 omit =
     imgix/compat.py
 
 [report]
 exclude_lines =
+    assert\(False\)
     pass

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -173,7 +173,7 @@ def test_invalid_domain_append_slash():
     try:
         imgix.UrlBuilder(url_append_slash)
     except ValueError:
-        pass
+        assert(True)
     else:
         assert(False)
 
@@ -185,7 +185,7 @@ def test_invalid_domain_prepend_scheme():
     try:
         imgix.UrlBuilder(url_prepend_protocol)
     except ValueError:
-        pass
+        assert(True)
     else:
         assert(False)
 
@@ -197,7 +197,7 @@ def test_invalid_domain_append_dash():
     try:
         imgix.UrlBuilder(url_append_dash)
     except ValueError:
-        pass
+        assert(True)
     else:
         assert(False)
 

--- a/tests/test_url_helper.py
+++ b/tests/test_url_helper.py
@@ -6,10 +6,6 @@ from imgix.compat import urlparse
 from imgix.urlhelper import UrlHelper
 
 
-def _default_helper():
-    return UrlHelper('my-social-network.imgix.net', '/users/1.png')
-
-
 def test_create():
     helper = UrlHelper('my-social-network.imgix.net', '/users/1.png')
     assert type(helper) is UrlHelper

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, core
+envlist = flake8, core, py27
 
 [flake8]
 exclude = .tox/*
@@ -14,6 +14,14 @@ commands =
     
     ;uncomment below if an html report is desired
     ;coverage html
+
+[testenv:py27]
+deps =
+    pytest
+    pytest-cov
+commands =
+    coverage run -m pytest
+    coverage report
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,11 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest -r sx --cov imgix tests {posargs}
+    coverage run -m pytest
+    coverage report
+    
+    ;uncomment below if an html report is desired
+    ;coverage html
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
This PR modifies the `tox` configuration to improve the accuracy of code coverage reports. It also adds parallel testing of python2 and python3.

Run command `tox`

Before:
```
============= test session starts =============
platform darwin -- Python 3.7.3, pytest-5.1.1, py-1.8.0, pluggy-0.12.0
cachedir: .tox/core/.pytest_cache
plugins: cov-2.7.1
collected 61 items

tests/test_srcset.py .................                           [ 27%]
tests/test_url_builder.py .......................                [ 65%]
tests/test_url_helper.py .....................                   [100%]
Coverage.py warning: No data was collected. (no-data-collected)


-------------------- coverage: platform darwin, python 3.7.3-final-0 --------------------
Name                  Stmts   Miss  Cover
-----------------------------------------
imgix/__init__.py         4      4     0%
imgix/_version.py         1      1     0%
imgix/constants.py        2      2     0%
imgix/urlbuilder.py      58     58     0%
imgix/urlhelper.py       62     62     0%
-----------------------------------------
TOTAL                   127    127     0%


================================== 61 passed in 0.28s ==================================
_________________________________________ summary ______________________________________
  flake8: commands succeeded
  core: commands succeeded
  congratulations :)
```

After:
```
============= test session starts =============
platform darwin -- Python 3.7.3, pytest-5.1.1, py-1.8.0, pluggy-0.12.0
cachedir: .tox/core/.pytest_cache
plugins: cov-2.7.1
collected 61 items

tests/test_srcset.py .................                          [ 27%]
tests/test_url_builder.py .......................               [ 65%]
tests/test_url_helper.py .....................                  [100%]

================================== 61 passed in 0.28s ==================================
core runtests: commands[1] | coverage report
Name                        Stmts   Miss  Cover
-----------------------------------------------
imgix/__init__.py               4      0   100%
imgix/_version.py               1      0   100%
imgix/constants.py              2      0   100%
imgix/urlbuilder.py            58      0   100%
imgix/urlhelper.py             62      4    94%
tests/test_srcset.py          153      0   100%
tests/test_url_builder.py     114      0   100%
tests/test_url_helper.py       81      0   100%
-----------------------------------------------
TOTAL                         475      4    99%

...

============= test session starts =============
platform darwin -- Python 2.7.10, pytest-4.6.5, py-1.8.0, pluggy-0.12.0
cachedir: .tox/py27/.pytest_cache
plugins: cov-2.7.1
collected 61 items

tests/test_srcset.py .................                            [ 27%]
tests/test_url_builder.py .......................                 [ 65%]
tests/test_url_helper.py .....................                    [100%]

...

======================== 61 passed, 1 warnings in 0.29 seconds =========================
py27 runtests: commands[1] | coverage report
Name                        Stmts   Miss  Cover
-----------------------------------------------
imgix/__init__.py               4      0   100%
imgix/_version.py               1      0   100%
imgix/constants.py              2      0   100%
imgix/urlbuilder.py            58      0   100%
imgix/urlhelper.py             62      0   100%
tests/test_srcset.py          153      0   100%
tests/test_url_builder.py     114      0   100%
tests/test_url_helper.py       81      0   100%
-----------------------------------------------
TOTAL                         475      0   100%
________________________________________ summary ________________________________________
  flake8: commands succeeded
  core: commands succeeded
  py27: commands succeeded
  congratulations :)
```