### PR TITLE
Fix Python 2/3 compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ docs/_build/
 
 .eggs/
 .pytest_cache/
+
+# IDE settings
+.vscode
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ python:
     - 3.7
     - 3.8
     - pypy
-
 env:
     - TOX_ENV=core
-    - TOX_ENV=flake8
+    - TOX_ENV=compat
+jobs:
+  include:
+    - python: 3.8
+      env: TOX_ENV=flake8
 
-install:
-    - pip install tox
-
-script:
-    - tox -e $TOX_ENV
+install: pip install .[dev]
+script: tox -e $TOX_ENV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,18 @@ If you wish to add a new feature or fix a bug:
 Running the tests
 -----------------
 
-To run the tests, simply:
+First, it's recommended you create a virtual environment:
+```
+python -m venv env/imgix
+source env/imgix/bin/activate
+```
+
+Then install the dev dependencies:
+```
+pip install .[dev]
+```
+
+To run the tests:
 ```
 tox
 ```
@@ -25,6 +36,13 @@ This will run all tests and check PEP8 compliance. Our test suite runs
 continuously on [Travis CI](https://travis-ci.org/imgix/imgix-python) with
 every pull request.
 
+To run tests in a specific environment:
+```
+tox -e p27  # Python 2.7
+tox -e core  # Your local Python version
+tox -e flake8  # To run the linter
+tox -e p27-compat  # Python 2.7 with future compatibility aliases
+```
 
 Publishing to PyPI
 ------------------

--- a/imgix/compat.py
+++ b/imgix/compat.py
@@ -1,25 +1,9 @@
 try:
     # Python 3
-    import urllib.parse as urlparse
-    from urllib.parse import urlencode
-    from urllib.parse import quote
-
-    def iteritems(a_dict):
-        return a_dict.items()
-
     def b(s):
         return s.encode("latin-1")
 
 except ImportError:
-    # Python 2.7
-    import urlparse
-    from urllib import urlencode
-    from urllib import quote
-
-    def iteritems(a_dict):
-        return a_dict.iteritems()
-
+    # Python 2
     def b(s):
         return s
-
-__all__ = ['iteritems', 'quote', 'urlparse', 'urlencode']

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-
 import re
 
-from .urlhelper import UrlHelper
-
 from .constants import DOMAIN_PATTERN, SRCSET_TARGET_WIDTHS
+from .urlhelper import UrlHelper
 
 
 SRCSET_DPR_TARGET_RATIOS = range(1, 6)

--- a/imgix/urlhelper.py
+++ b/imgix/urlhelper.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-
-import hashlib
 from base64 import urlsafe_b64encode
+from future.moves.urllib.parse import quote, urlunparse
+from future.utils import iteritems
+import hashlib
 
-from .compat import iteritems
-from .compat import urlparse
-from .compat import quote
 from .compat import b
-
 from ._version import __version__
 
 
@@ -152,7 +149,7 @@ class UrlHelper(object):
             else:
                 query = "s=" + signature
 
-        return urlparse.urlunparse([
+        return urlunparse([
             self._scheme,
             self._host,
             path,

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,28 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 import codecs
+import io
+import re
 
-from imgix._version import __version__
 from setuptools import setup
+
+with io.open("imgix/_version.py", "rt", encoding="utf8") as f:
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 with codecs.open('README.md', encoding='utf-8') as fp:
     readme = fp.read()
 with codecs.open('CHANGELOG.md', encoding='utf-8') as fp:
     changelog = fp.read()
 
+test_require = [
+    'pytest',
+    'pytest-cov',
+    'flake8',
+]
 
 setup(
     name='imgix',
-    version=__version__,
+    version=version,
     author='imgix',
     author_email='support@imgix.com',
     packages=['imgix'],
@@ -36,9 +44,13 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-    setup_requires=['pytest-runner'],
-    tests_require=[
-        'pytest',
-        'pytest-cov',
+    install_requires=[
+        'future',
     ],
-    )
+    setup_requires=['pytest-runner'],
+    extras_require={
+        'dev': ['tox'],
+        'test': test_require,
+    },
+    tests_require=test_require,
+)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import os
+
+if os.environ.get('COMPAT_ENV'):
+    # Due to how PyTest runs tests, it is not possible to
+    # call `install_aliases` on a per-test basis.
+    # To workaround this, we rely on Tox conditionally setting
+    # this env variable to run all the tests with and without the
+    # compatibility aliases.
+    from future import standard_library
+    standard_library.install_aliases()

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-
 import imgix
 
-from imgix.compat import urlparse
+from future.moves.urllib.parse import urlparse
 
 
 def _get_domain(url):
-    return urlparse.urlparse(url).hostname
+    return urlparse(url).hostname
 
 
 def _default_builder():
@@ -101,19 +100,19 @@ def test_use_https():
     # Defaults to https
     builder = imgix.UrlBuilder('my-social-network.imgix.net')
     url = builder.create_url("/users/1.png")
-    assert urlparse.urlparse(url).scheme == "https"
+    assert urlparse(url).scheme == "https"
 
     builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=False)
     url = builder.create_url("/users/1.png")
-    assert urlparse.urlparse(url).scheme == "http"
+    assert urlparse(url).scheme == "http"
 
     builder = imgix.UrlBuilder('my-social-network.imgix.net', True)
     url = builder.create_url("/users/1.png")
-    assert urlparse.urlparse(url).scheme == "https"
+    assert urlparse(url).scheme == "https"
 
     builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=True)
     url = builder.create_url("/users/1.png")
-    assert urlparse.urlparse(url).scheme == "https"
+    assert urlparse(url).scheme == "https"
 
 
 def test_utf_8_characters():

--- a/tests/test_url_helper.py
+++ b/tests/test_url_helper.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-
 import imgix
 
-from imgix.compat import urlparse
+from future.moves.urllib.parse import urlparse
 from imgix.urlhelper import UrlHelper
 
 
@@ -67,14 +66,25 @@ def test_create_with_fully_qualified_url_with_special_chars():
                           "?s=8e04a5dd9a659a6a540d7c817d3df1d3"
 
 
+def test_create_with_mixed_strings_and_unicodes():
+    helper = UrlHelper("my-social-network.imgix.net",
+                       u"http://avatars.com/でのパ.png",
+                       sign_key="FOO123bar",
+                       params={"w": '400', u"h": u'300'},
+                       include_library_param=False)
+    assert str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F" \
+                          "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png" \
+                          "?h=300&w=400&s=8b97a8fffdfa639af4bae846a9661c50"
+
+
 def test_use_https():
     # Defaults to https
     helper = UrlHelper("my-social-network.imgix.net", "/users/1.png")
-    assert urlparse.urlparse(str(helper)).scheme == "https"
+    assert urlparse(str(helper)).scheme == "https"
 
     helper = UrlHelper('my-social-network.imgix.net', "/users/1.png",
                        scheme="http")
-    assert urlparse.urlparse(str(helper)).scheme == "http"
+    assert urlparse(str(helper)).scheme == "http"
 
 
 def test_utf_8_characters():

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,14 @@
 [tox]
-envlist = flake8, core, py27
+envlist = flake8, core, compat, py27, py27-compat
 
-[flake8]
-exclude = .tox/*
-
-[testenv:core]
+[testenv]
 deps =
-    pytest
-    pytest-cov
+    .[test]
 commands =
-    coverage run -m pytest
-    coverage report
-    
-    ;uncomment below if an html report is desired
-    ;coverage html
-
-[testenv:py27]
-deps =
-    pytest
-    pytest-cov
-commands =
-    coverage run -m pytest
-    coverage report
+    pytest --cov=imgix {posargs}
+setenv = 
+    compat: COMPAT_ENV=True
 
 [testenv:flake8]
-deps = flake8
-commands = flake8 setup.py imgix tests
+commands = 
+    flake8 setup.py imgix tests


### PR DESCRIPTION
Fixes https://github.com/imgix/imgix-python/issues/40.

The issue was that [`compat.py`](https://github.com/imgix/imgix-python/blob/92509f246d489ac2896bd3b0ba981c6c66f7ac8d/imgix/compat.py) did not handle correctly all the edge cases around `urllib`. In addition to aliasing sub-modules, [`future`](https://python-future.org/standard_library_imports.html#aliased-imports) backports some `urllib` sub-modules so it can better deal with mixed encodings.

I had to refactor how the tests are setup in order to run them with and without the compatibility aliases. Due to how `pytest` share environments across tests, it was not possible to conditionally install the aliases on a per-test basis. Now all the tests, except for Flake8, will run in both regular and compatibility modes. This should prevent future regressions.

Let me know if you have any questions.