### PR TITLE
fix: improve tox integration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ commands =
 setenv = 
     compat: COMPAT_ENV=True
 
-[testenv:flake8]
+[testenv.flake8]
 commands = 
     flake8 setup.py imgix tests


### PR DESCRIPTION
This commit attempts to improve the integration between `tox` and `flake8`.
Prior to this commit a colon, `:`, was used at the separator in:
```
[testenv:flake8]
```
which causes flake8 to error and exit "1"

After this commit the separator is now a `.`
```
[testenv.flake8]
```
If this passes CI, it's an improvement. If not, this request can be closed.