### PR TITLE
refactor: abstract validators

### DIFF
--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -8,6 +8,21 @@ DOMAIN_PATTERN = re.compile(
 SRCSET_INCREMENT_PERCENTAGE = 8
 SRCSET_MAX_SIZE = 8192
 
+# The percentage by which image width-values are incremented by for
+# use in generating the default set of image widths, i.e.
+# `[IMAGE_MIN_WIDTH, .., IMAGE_MAX_WIDTH]`.
+INCREMENT_PERCENTAGE = 0.08
+
+# Representation of an image with a width of zero. This value is used
+# in validation contexts, i.e. "is the width of the passed or requested
+# image greater than or equal to the 'zero width image'."
+IMAGE_ZERO_WIDTH = 0.0
+
+# The minimum width of a default generated image-width.
+IMAGE_MIN_WIDTH = 100.0
+
+# The maximum width of a default generate image-width.
+IMAGE_MAX_WIDTH = 8192.0
 
 def _target_widths():
     resolutions = []

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -5,13 +5,13 @@ DOMAIN_PATTERN = re.compile(
             r'(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)'
             r'[a-z\d]{1,63}$'
         )
-SRCSET_INCREMENT_PERCENTAGE = 8
-SRCSET_MAX_SIZE = 8192
 
-# The percentage by which image width-values are incremented by for
-# use in generating the default set of image widths, i.e.
-# `[IMAGE_MIN_WIDTH, .., IMAGE_MAX_WIDTH]`.
-INCREMENT_PERCENTAGE = 0.08
+# The srcset width tolerance dictates the _maximum tolerated size_
+# difference between an image's downloaded size and its rendered size.
+# For example, setting this value to 0.1 means that an image will not
+# render more than 10% larger or smaller than its native size.
+SRCSET_WIDTH_TOLERANCE = 8
+SRCSET_MAX_SIZE = 8192
 
 # Representation of an image with a width of zero. This value is used
 # in validation contexts, i.e. "is the width of the passed or requested
@@ -34,7 +34,7 @@ def _target_widths():
 
     while prev <= SRCSET_MAX_SIZE:
         resolutions.append(int(ensure_even(prev)))
-        prev *= 1 + (SRCSET_INCREMENT_PERCENTAGE / 100.0) * 2
+        prev *= 1 + (SRCSET_WIDTH_TOLERANCE / 100.0) * 2
 
     resolutions.append(SRCSET_MAX_SIZE)
     return resolutions

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -24,6 +24,7 @@ IMAGE_MIN_WIDTH = 100.0
 # The maximum width of a default generate image-width.
 IMAGE_MAX_WIDTH = 8192.0
 
+
 def _target_widths():
     resolutions = []
     prev = 100

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -16,13 +16,13 @@ SRCSET_MAX_SIZE = 8192
 # Representation of an image with a width of zero. This value is used
 # in validation contexts, i.e. "is the width of the passed or requested
 # image greater than or equal to the 'zero width image'."
-IMAGE_ZERO_WIDTH = 0.0
+IMAGE_ZERO_WIDTH = 0
 
 # The minimum width of a default generated image-width.
-IMAGE_MIN_WIDTH = 100.0
+IMAGE_MIN_WIDTH = 100
 
 # The maximum width of a default generate image-width.
-IMAGE_MAX_WIDTH = 8192.0
+IMAGE_MAX_WIDTH = 8192
 
 
 def _target_widths():

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -1,7 +1,6 @@
-from .constants import IMAGE_MIN_WIDTH as MIN_WIDTH
 from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
 from .constants import IMAGE_ZERO_WIDTH as ZERO_WIDTH
-from .constants import INCREMENT_PERCENTAGE
+
 
 def validate_min_width(value):
     """
@@ -21,22 +20,24 @@ def validate_min_width(value):
     AssertionError
         This function is designed to fail upon invalid input to
         prevent the propagation of invalid state.
-    
+
     Parameters
     ----------
     value : float, int
         A valid `value` must be a positive numerical value.
     """
-    invalid_width_error = 'error: `min_width` must be a positive `float` or `int`'
+    invalid_width_error = 'error: `min_width` must be a positive ' \
+        '`float` or `int`'
     assert isinstance(value, (float, int)), invalid_width_error
 
     invalid_min_error = 'error: `min_width` must be greater than zero'
     assert value > ZERO_WIDTH, invalid_min_error
 
+
 def validate_max_width(value):
     """
     Validate the maximum width value.
-    
+
     This function ensures that the `value`:
     * is of type `int`, or
     * is of type `float`, and
@@ -53,18 +54,19 @@ def validate_max_width(value):
     AssertionError
         This function is designed to fail upon invalid input to
         prevent the propagation of invalid state.
-    
+
     Parameters
     ----------
     value : float, int
         A valid `value` must be a positive numerical value.
     """
-    invalid_width_error = 'error: `max_width` must be a positive `float` or `int`'
+    invalid_width_error = 'error: `max_width` must be a positive ' \
+        '`float` or `int`'
     assert isinstance(value, (float, int)), invalid_width_error
 
     invalid_max_error = 'error: `max_width` must be <= 8192.0'
     assert ZERO_WIDTH < value <= MAX_WIDTH, invalid_max_error
-        
+
 
 def validate_range(min_width, max_width):
     """

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -1,0 +1,98 @@
+from .constants import IMAGE_MIN_WIDTH as MIN_WIDTH
+from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
+from .constants import IMAGE_ZERO_WIDTH as ZERO_WIDTH
+from .constants import INCREMENT_PERCENTAGE
+
+def validate_min_width(value):
+    """
+    Validate the minimum width value.
+
+    This function ensures that the `value`:
+    * is of type `int`, or
+    * is of type `float`, and
+    * is greater than the `ZERO_WIDTH`
+
+    This function is used to ensure custom minimum widths are within
+    a valid range. Here, valid means that the minimum width value must
+    an int, or a float, and be greater than zero.
+
+    Raises
+    ------
+    AssertionError
+        This function is designed to fail upon invalid input to
+        prevent the propagation of invalid state.
+    
+    Parameters
+    ----------
+    value : float, int
+        A valid `value` must be a positive numerical value.
+    """
+    invalid_width_error = 'error: `min_width` must be a positive `float` or `int`'
+    assert isinstance(value, (float, int)), invalid_width_error
+
+    invalid_min_error = 'error: `min_width` must be greater than zero'
+    assert value > ZERO_WIDTH, invalid_min_error
+
+def validate_max_width(value):
+    """
+    Validate the maximum width value.
+    
+    This function ensures that the `value`:
+    * is of type `int`, or
+    * is of type `float`, and
+    * is greater than the `ZERO_WIDTH`, and
+    * is less than or equal to the `MAX_WIDTH`
+
+    This function is used to ensure custom maximum widths are within
+    a valid range. Here, valid means that the maximum width value must
+    an int, or a float, be greater than zero, and be less than or equal
+    to the maximum value.
+
+    Raises
+    ------
+    AssertionError
+        This function is designed to fail upon invalid input to
+        prevent the propagation of invalid state.
+    
+    Parameters
+    ----------
+    value : float, int
+        A valid `value` must be a positive numerical value.
+    """
+    invalid_width_error = 'error: `max_width` must be a positive `float` or `int`'
+    assert isinstance(value, (float, int)), invalid_width_error
+
+    invalid_max_error = 'error: `max_width` must be <= 8192.0'
+    assert ZERO_WIDTH < value <= MAX_WIDTH, invalid_max_error
+        
+
+def validate_range(min_width, max_width):
+    """
+    Validate the minimum and maximum width values are in range.
+
+    This function ensures that the values `min_width` and `max_width`:
+    * each pass their respective validations, i.e. `validate_min_width`
+      for `min_width`
+    * represent a valid range, i.e. the minimum value is less than the
+      maximum value.
+
+    Raises
+    ------
+    AssertionError
+        This function is designed to fail upon invalid input to
+        prevent the propagation of invalid state.
+
+    Parameters
+    ----------
+    min_width : float, int
+        The value representing the lower bound, i.e. in the list [1, 2, 3]
+        1 is the lower bound.
+    max_width : float, int
+        The value representing the upper bound, i.e. in the list [1, 2, 3]
+        3 is the upper bound.
+    """
+    validate_min_width(min_width)
+    validate_max_width(max_width)
+
+    invalid_range_error = 'error: `min_width` must be less than `max_width`'
+    assert min_width < max_width, invalid_range_error

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,58 @@
+import unittest
+
+from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
+    IMAGE_ZERO_WIDTH
+
+from imgix.validators import validate_min_width, validate_max_width, \
+    validate_range
+
+class TestValidators(unittest.TestCase):
+
+    def test_validate_min_raises(self):
+        with self.assertRaises(AssertionError):
+            validate_min_width(-1)
+
+        with self.assertRaises(AssertionError):
+            validate_min_width("1")
+
+        with self.assertRaises(AssertionError):
+            validate_min_width(IMAGE_ZERO_WIDTH)
+
+        with self.assertRaises(AssertionError):
+            validate_min_width([-1])
+
+    def test_validate_max_raises(self):
+        with self.assertRaises(AssertionError):
+            validate_max_width(-1)
+
+        with self.assertRaises(AssertionError):
+            validate_max_width("1")
+
+        with self.assertRaises(AssertionError):
+            validate_max_width(IMAGE_ZERO_WIDTH)
+
+        with self.assertRaises(AssertionError):
+            validate_max_width([-1])
+
+        with self.assertRaises(AssertionError):
+            validate_max_width(IMAGE_MAX_WIDTH+1)
+
+    def test_validate_range_raises(self):
+        # Each x, y or <min, max> pair should fail in
+        # because they are equal in every case.
+        for x, y in enumerate([x for x in range(10)]):
+            with self.assertRaises(AssertionError):
+                validate_range(x, y)
+
+        
+        with self.assertRaises(AssertionError):
+            validate_range(IMAGE_ZERO_WIDTH, IMAGE_ZERO_WIDTH)
+
+        with self.assertRaises(AssertionError):
+            validate_range(IMAGE_MIN_WIDTH, IMAGE_MIN_WIDTH)
+
+        with self.assertRaises(AssertionError):
+            validate_range(IMAGE_ZERO_WIDTH, IMAGE_MAX_WIDTH)
+
+        with self.assertRaises(AssertionError):
+            validate_range(IMAGE_MAX_WIDTH, IMAGE_MAX_WIDTH)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -6,6 +6,7 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
 from imgix.validators import validate_min_width, validate_max_width, \
     validate_range
 
+
 class TestValidators(unittest.TestCase):
 
     def test_validate_min_raises(self):
@@ -44,7 +45,6 @@ class TestValidators(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 validate_range(x, y)
 
-        
         with self.assertRaises(AssertionError):
             validate_range(IMAGE_ZERO_WIDTH, IMAGE_ZERO_WIDTH)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ commands =
 setenv = 
     compat: COMPAT_ENV=True
 
-[testenv.flake8]
+[testenv:flake8]
 commands = 
     flake8 setup.py imgix tests

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ commands =
 setenv = 
     compat: COMPAT_ENV=True
 
-[testenv:flake8]
+[testenv.flake8]
 commands = 
     flake8 setup.py imgix tests


### PR DESCRIPTION
This commit introduces `validators.py`. It isn't a feature, it's a
utility. Abstracting validation out of individual files (where it
makes sense to) helps us validate and test better.

Instead of growing individual files with validation code,
`validators.py` can grow. It can grow so much that eventually
it could become
```text
validators
├── v0.py
└── v1.py
```
if necessary.

This commit is a part of my agenda to promote modularity and
plug-ability. These validators can be used and reused,
internally and externally.

This commit also defines the dependencies it needs:
```
INCREMENT_PERCENTAGE = 0.08

IMAGE_ZERO_WIDTH = 0.0

IMAGE_MIN_WIDTH = 100.0

IMAGE_MAX_WIDTH = 8192.0
```
They are additions to `SRCSET_MAX_SIZE` & `SRCSET_INCREMENT_PERCENTAGE`.
I've added constants rather than remove/exchange to give us any and all
time needed to deprecate ambiguously constants (if we choose).

The purpose of defining these constants is to unify common values that
are used throughout the codebase (e.g. the raw value `8192` is used
three times in `test_srcset.py` alone).

Note that the minimum value is _our_ minimum default value. Also note
that while `IMAGE_ZERO_WIDTH` provides some benefit now, I'm confident
it will pay dividends in the future.

Each new validator is accompanied by a **group** of test functions
located in `imgix-python/tests/test_validators.py`.

This commit is in preparation for generating custom widths.

**Edit**:
In the original commit I changed the `tox.ini` file in an attempt to "improve" the
integration. However, this was incorrect. I'm not entirely sure what happened,
but I think introducing incorrect `tox.ini` syntax caused the flake8 checks to
not be run. Since, I've made some whitespace changes to comply with flake8's
demands ;)

- [x] **All tests _actually_ pass now**
- [x] CI Checks

