### PR TITLE
chore: clean up remnant SIGNATURE_MODE artifacts

### DIFF
--- a/imgix/__init__.py
+++ b/imgix/__init__.py
@@ -25,4 +25,4 @@ from .urlbuilder import UrlBuilder
 
 __all__ = [
     'UrlBuilder',
-    'SIGNATURE_MODE_QUERY', 'SIGNATURE_MODE_PATH', '__version__', ]
+    '__version__']


### PR DESCRIPTION
Cleans up artifacts of the `SIGNATURE_MODE` feature, which was deprecated/removed in #35.