### PR TITLE
feat: create custom srcset

### DIFF
--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -11,6 +11,10 @@ DOMAIN_PATTERN = re.compile(
 # For example, setting this value to 0.1 means that an image will not
 # render more than 10% larger or smaller than its native size.
 SRCSET_WIDTH_TOLERANCE = 8
+
+# The minimum srcset width tolerance.
+SRCSET_MIN_WIDTH_TOLERANCE = 1
+
 SRCSET_MAX_SIZE = 8192
 
 # Representation of an image with a width of zero. This value is used

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -15,6 +15,9 @@ SRCSET_WIDTH_TOLERANCE = 8
 # The minimum srcset width tolerance.
 SRCSET_MIN_WIDTH_TOLERANCE = 1
 
+# The default srcset target ratios.
+SRCSET_DPR_TARGET_RATIOS = range(1, 6)
+
 SRCSET_MAX_SIZE = 8192
 
 # Representation of an image with a width of zero. This value is used

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -1,5 +1,6 @@
 from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
 from .constants import IMAGE_ZERO_WIDTH as ZERO_WIDTH
+from .constants import SRCSET_MIN_WIDTH_TOLERANCE as ONE_PERCENT
 
 
 def validate_min_width(value):
@@ -98,3 +99,45 @@ def validate_range(min_width, max_width):
 
     invalid_range_error = 'error: `min_width` must be less than `max_width`'
     assert min_width < max_width, invalid_range_error
+
+
+def validate_width_tol(value):
+    """
+    Validate the width tolerance.
+
+    This function ensures that the width tolerance `value` is  greater than or
+    equal to 1, where 1 represents a width tolerance of 1%.
+
+    Note: `value` can be either a float or an int, but this is only to yield
+    flexibility to the caller.
+
+    Parameters
+    ----------
+    value : float, int
+        Numerical value, typically within the range of [1, 100]. It can be
+        greater than 100, but no less than 1.
+    """
+    invalid_tol_error = 'tolerance `value` must be a positive numerical value'
+    assert isinstance(value, (float, int)), invalid_tol_error
+    assert ONE_PERCENT <= value, invalid_tol_error
+
+
+def validate_min_max_tol(min_width, max_width, tol):
+    """
+    Validate the minimum, maximum, and tolerance values.
+
+    This function is composed of two other validators and exists to provide
+    convenience at the call site, i.e. instead of calling three functions to
+    validate this triplet, one function can be called.
+
+    Parameters
+    ----------
+    min_width : float, int
+        Minimum renderable image width requested, by default.
+    max_width : float, int
+        Maximum renderable image width requested, by default.
+    tol : float, int
+        Tolerable amount of image width variation requested, by default.
+    """
+    validate_range(min_width, max_width)
+    validate_width_tol(tol)

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -2,6 +2,9 @@
 import imgix
 
 from future.moves.urllib.parse import urlparse
+from imgix import constants
+from imgix import urlbuilder
+from imgix.constants import IMAGE_MAX_WIDTH, IMAGE_MIN_WIDTH
 
 
 def _get_domain(url):
@@ -214,3 +217,36 @@ def test_include_library_param_false():
     ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=False)
 
     assert url == ub.create_url("image.jpg")
+
+
+def test_target_widths_default():
+    expected = constants.SRCSET_TARGET_WIDTHS
+    actual = urlbuilder.target_widths()
+    assert len(actual) == len(expected)
+    assert actual == expected
+
+
+def test_target_widths_100_7400():
+    idx_of_7400 = -1
+    expected = constants.SRCSET_TARGET_WIDTHS[:idx_of_7400]
+    actual = urlbuilder.target_widths(start=100, stop=7400)
+    assert actual == expected
+
+
+def test_target_widths_380_4088():
+    idx_of_328, idx_of_4088 = 8, -5
+    expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328: idx_of_4088]
+    actual = urlbuilder.target_widths(start=328, stop=4088)
+    assert len(actual) == len(expected)
+    assert actual[0] == expected[0]
+    assert actual[-1] == expected[-1]
+
+
+def test_target_widths_100_max():
+    idx_of_100 = constants.SRCSET_TARGET_WIDTHS[0]
+    idx_of_8192 = constants.SRCSET_TARGET_WIDTHS[-1]
+    expected = [idx_of_100, idx_of_8192]
+    actual = urlbuilder.target_widths(tol=10000000000)
+    assert actual == expected
+    assert actual[0] == IMAGE_MIN_WIDTH
+    assert actual[-1] == IMAGE_MAX_WIDTH

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,7 +4,7 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
     IMAGE_ZERO_WIDTH
 
 from imgix.validators import validate_min_width, validate_max_width, \
-    validate_range
+    validate_range, validate_min_max_tol
 
 
 class TestValidators(unittest.TestCase):
@@ -56,3 +56,13 @@ class TestValidators(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             validate_range(IMAGE_MAX_WIDTH, IMAGE_MAX_WIDTH)
+
+    def test_validate_min_max_tol_raises(self):
+
+        with self.assertRaises(AssertionError):
+            # `IMAGE_ZERO_WIDTH` is being used to
+            # simulate a `tol` < ONE_PERCENT.
+            validate_min_max_tol(
+                IMAGE_ZERO_WIDTH,
+                IMAGE_ZERO_WIDTH,
+                IMAGE_ZERO_WIDTH)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,7 +1,7 @@
 import unittest
 
 from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
-    IMAGE_ZERO_WIDTH
+    IMAGE_ZERO_WIDTH, SRCSET_MIN_WIDTH_TOLERANCE
 
 from imgix.validators import validate_min_width, validate_max_width, \
     validate_range, validate_min_max_tol
@@ -63,6 +63,14 @@ class TestValidators(unittest.TestCase):
             # `IMAGE_ZERO_WIDTH` is being used to
             # simulate a `tol` < ONE_PERCENT.
             validate_min_max_tol(
-                IMAGE_ZERO_WIDTH,
-                IMAGE_ZERO_WIDTH,
+                IMAGE_MIN_WIDTH,
+                IMAGE_MAX_WIDTH,
                 IMAGE_ZERO_WIDTH)
+
+    def test_validate_min_max_tol(self):
+        # Due to the assertive nature of this validator
+        # if this test does not raise, it passes.
+        validate_min_max_tol(
+            IMAGE_MIN_WIDTH,
+            IMAGE_MAX_WIDTH,
+            SRCSET_MIN_WIDTH_TOLERANCE)


### PR DESCRIPTION
The purpose of this PR is to implement custom srcset behavior by supporting:
* custom min and max widths
* custom width tolerance

This PR also seeks to do this without changing the public API.

This PR has been split into three commits:
* **validate min, max, and width tolerance**
  * to call one validator instead of three
  * test
* **implement custom target widths**
  * pull target width generation into `UrlBuilder.py`
  * this is where the validation occurs
  * test
* **custom srcset widths and tolerance**
  * validation is done here as well (so that `create_srcset` and `target_widths` can be used separately)
  * extend the API to support custom srcset generation by specifying:
    * custom min/max widths and 
    * width tolerance.

Note: There have been 220 additions and 25 deletions here, however, more than 117 of theses additions are documentation and comments.

EDIT: The fourth commit improves the test cases for `validate_min_max_tol`