### PR TITLE
refactor: correct test function name

### DIFF
--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -233,7 +233,7 @@ def test_target_widths_100_7400():
     assert actual == expected
 
 
-def test_target_widths_380_4088():
+def test_target_widths_328_4088():
     idx_of_328, idx_of_4088 = 8, -5
     expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328: idx_of_4088]
     actual = urlbuilder.target_widths(start=328, stop=4088)


### PR DESCRIPTION
This PR changes a function's name to what it should be called.

From:
```python
 test_target_widths_380_4088():
```
To:
```python
 test_target_widths_328_4088():
```
No behavior has been changed. I noticed this while going over the
same kind of function in php. I guess I snuck this in; luckily, the
variable names hinted something was off.