### PR TITLE
refactor: normalize behavior of target widths

### DIFF
--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -270,10 +270,13 @@ def target_widths(start=MIN_WIDTH, stop=MAX_WIDTH, tol=TOLERANCE):
     if not CUSTOM:
         return TARGET_WIDTHS
 
-    resolutions = []
-
     def make_even_integer(n):
         return int(2 * round(n/2.0))
+
+    if start == stop:
+        return [make_even_integer(start)]
+
+    resolutions = []
 
     while start < stop and start < MAX_WIDTH:
         resolutions.append(make_even_integer(start))

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -286,6 +286,6 @@ def target_widths(start=MIN_WIDTH, stop=MAX_WIDTH, tol=TOLERANCE):
     # the `stop` value. In order to be inclusive of the
     # stop value, check for this case and add it, if necessary.
     if resolutions[-1] < stop:
-        resolutions.append(stop)
+        resolutions.append(make_even_integer(stop))
 
     return resolutions

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -98,7 +98,7 @@ def validate_range(min_width, max_width):
     validate_max_width(max_width)
 
     invalid_range_error = '`min_width` must be less than `max_width`'
-    assert min_width < max_width, invalid_range_error
+    assert min_width <= max_width, invalid_range_error
 
 
 def validate_width_tol(value):

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -250,3 +250,9 @@ def test_target_widths_100_max():
     assert actual == expected
     assert actual[0] == IMAGE_MIN_WIDTH
     assert actual[-1] == IMAGE_MAX_WIDTH
+
+
+def test_target_widths_328_to_328():
+    expected = [328]
+    actual = urlbuilder.target_widths(start=328, stop=328)
+    assert actual == expected

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -39,23 +39,15 @@ class TestValidators(unittest.TestCase):
             validate_max_width(IMAGE_MAX_WIDTH+1)
 
     def test_validate_range_raises(self):
-        # Each x, y or <min, max> pair should fail in
-        # because they are equal in every case.
-        for x, y in enumerate([x for x in range(10)]):
-            with self.assertRaises(AssertionError):
-                validate_range(x, y)
 
         with self.assertRaises(AssertionError):
             validate_range(IMAGE_ZERO_WIDTH, IMAGE_ZERO_WIDTH)
 
         with self.assertRaises(AssertionError):
-            validate_range(IMAGE_MIN_WIDTH, IMAGE_MIN_WIDTH)
-
-        with self.assertRaises(AssertionError):
             validate_range(IMAGE_ZERO_WIDTH, IMAGE_MAX_WIDTH)
 
         with self.assertRaises(AssertionError):
-            validate_range(IMAGE_MAX_WIDTH, IMAGE_MAX_WIDTH)
+            validate_range(IMAGE_MAX_WIDTH, IMAGE_MIN_WIDTH)
 
     def test_validate_min_max_tol_raises(self):
 
@@ -74,3 +66,10 @@ class TestValidators(unittest.TestCase):
             IMAGE_MIN_WIDTH,
             IMAGE_MAX_WIDTH,
             SRCSET_MIN_WIDTH_TOLERANCE)
+
+    def test_start_equals_stop(self):
+        # Due to the assertive nature of this validator
+        # if this test does not raise, it passes.
+        for x, y in enumerate([x for x in range(1, 10)], start=1):
+            assert x == y
+            validate_range(x, y)


### PR DESCRIPTION
This PR seeks to normalize the behavior of target widths (kit wide).
Prior, it was an error to set `start = stop` when generating a range
of target width values. This has been relaxed and it is no longer an
error making generating target width lists of length 1 possible.