### PR TITLE
refactor: remove ensure even

### DIFF
--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -35,19 +35,8 @@ IMAGE_MAX_WIDTH = 8192
 DPR_QUALITIES = {1: 75, 2: 50, 3: 35, 4: 23, 5: 20}
 
 
-def _target_widths():
-    resolutions = []
-    prev = 100
-
-    def ensure_even(n):
-        return 2 * round(n/2.0)
-
-    while prev <= SRCSET_MAX_SIZE:
-        resolutions.append(int(ensure_even(prev)))
-        prev *= 1 + (SRCSET_WIDTH_TOLERANCE / 100.0) * 2
-
-    resolutions.append(SRCSET_MAX_SIZE)
-    return resolutions
-
-
-SRCSET_TARGET_WIDTHS = _target_widths()
+SRCSET_TARGET_WIDTHS = [
+    100, 116, 135, 156, 181, 210, 244, 283,
+    328, 380, 441, 512, 594, 689, 799, 927,
+    1075, 1247, 1446, 1678, 1946, 2257, 2619,
+    3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192]

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -270,22 +270,19 @@ def target_widths(start=MIN_WIDTH, stop=MAX_WIDTH, tol=TOLERANCE):
     if not CUSTOM:
         return TARGET_WIDTHS
 
-    def make_even_integer(n):
-        return int(2 * round(n/2.0))
-
     if start == stop:
-        return [make_even_integer(start)]
+        return [start]
 
     resolutions = []
 
     while start < stop and start < MAX_WIDTH:
-        resolutions.append(make_even_integer(start))
+        resolutions.append(round(start))
         start *= 1 + (tol / 100.0) * 2
 
     # The most recently appended value may, or may not, be
     # the `stop` value. In order to be inclusive of the
     # stop value, check for this case and add it, if necessary.
     if resolutions[-1] < stop:
-        resolutions.append(make_even_integer(stop))
+        resolutions.append(stop)
 
     return resolutions

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -226,17 +226,17 @@ def test_target_widths_default():
     assert actual == expected
 
 
-def test_target_widths_100_7400():
-    idx_of_7400 = -1
-    expected = constants.SRCSET_TARGET_WIDTHS[:idx_of_7400]
-    actual = urlbuilder.target_widths(start=100, stop=7400)
+def test_target_widths_100_7401():
+    idx_of_7401 = -1
+    expected = constants.SRCSET_TARGET_WIDTHS[:idx_of_7401]
+    actual = urlbuilder.target_widths(start=100, stop=7401)
     assert actual == expected
 
 
-def test_target_widths_328_4088():
-    idx_of_328, idx_of_4088 = 8, -5
-    expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328: idx_of_4088]
-    actual = urlbuilder.target_widths(start=328, stop=4088)
+def test_target_widths_328_4087():
+    idx_of_328, idx_of_4087 = 8, -5
+    expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328: idx_of_4087]
+    actual = urlbuilder.target_widths(start=328, stop=4087)
     assert len(actual) == len(expected)
     assert actual[0] == expected[0]
     assert actual[-1] == expected[-1]


### PR DESCRIPTION
The purpose of this PR is to remove the `ensure_even` requirement.

Previously, image target widths were required to be even integer values.
The original line of thought accounted for physical device pixel dimension
evenness; however, this is important only if images are rendered at full
viewport width.

Since this is not always the case, we wanted to include both odd and even
values here to give users more flexibility and to better meet user expectations:
i.e. if widths [115, …, 2121] were requested, then [116, …, 2122] could be
considered unexpected.

This PR also changes the default source set target widths; the values
have been updated to reflect the above changes. The values are also
assigned as a list (whereas assignment to `SRCSET_TARGET_WIDTHS`
was being done via function call).