### PR TITLE
refactor: improve feature flexibility

### DIFF
--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -160,15 +160,14 @@ class UrlBuilder(object):
             Stopping maximum width value, MAX_WIDTH by default.
         tol : int, optional
             Tolerable amount of width value variation, TOLERANCE by default.
-        targets: list, optional
+        widths: list, optional
             List of target widths, `TARGET_WIDTHS` by default.
         Returns
         -------
         str
             Srcset attribute string.
         """
-        # Review: 'targets' or 'widths'?
-        targets_list = kwargs.get('targets', None)
+        targets_list = kwargs.get('widths', None)
         if targets_list:
             return self._build_srcset_pairs(path, params, targets=targets_list)
 
@@ -184,9 +183,9 @@ class UrlBuilder(object):
         # target widths.
         generated_targets = None
         if start or stop or tol:
-            _start = start if start else MIN_WIDTH
-            _stop = stop if stop else MAX_WIDTH
-            _tol = tol if tol else TOLERANCE
+            _start = start or MIN_WIDTH
+            _stop = stop or MAX_WIDTH
+            _tol = tol or TOLERANCE
 
             validate_min_max_tol(_start, _stop, _tol)
 

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -67,7 +67,7 @@ def test_srcset_pair_values():
 
 def test_create_srcset_with_widths():
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
-    actual = ub.create_srcset(JPG_PATH, targets=[100, 200, 300, 400, 500])
+    actual = ub.create_srcset(JPG_PATH, widths=[100, 200, 300, 400, 500])
     expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
         "https://testing.imgix.net/image.jpg?w=200 200w,\n" + \
         "https://testing.imgix.net/image.jpg?w=300 300w,\n" + \

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -65,6 +65,51 @@ def test_srcset_pair_values():
         index += 1
 
 
+def test_create_srcset_with_widths():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(JPG_PATH, targets=[100, 200, 300, 400, 500])
+    expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=200 200w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=300 300w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=400 400w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=500 500w"
+
+    assert(expected == actual)
+
+
+def test_create_srcset_start_equals_stop():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(JPG_PATH, start=713, stop=713)
+    expected = "https://testing.imgix.net/image.jpg?w=713 713w"
+
+    assert(expected == actual)
+
+
+def test_create_srcset_2257_to_4087():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(JPG_PATH, start=2257, stop=4087)
+    expected = "https://testing.imgix.net/image.jpg?w=2257 2257w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=2618 2618w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=3037 3037w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=3523 3523w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=4087 4087w"
+
+    assert(expected == actual)
+
+
+def test_create_srcset_100_to_108():
+    # Test that `tol=1` produces the correct spread.
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(JPG_PATH, start=100, stop=108, tol=1)
+    expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=102 102w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=104 104w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=106 106w,\n" + \
+        "https://testing.imgix.net/image.jpg?w=108 108w"
+
+    assert(expected == actual)
+
+
 def test_given_width_srcset_is_DPR():
     srcset = _default_srcset({'w': 100})
     device_pixel_ratio = 1


### PR DESCRIPTION
The purpose of this PR is to normalize feature behavior, specifically
custom srcset behavior.

Prior to this PR the `create_srcset` method accepted four key-worded
arguments. Now, those arguments have been replaced with `**kwargs`.

This PR also ensures that widths produced via `target_widths` are
`int` values to ensure that the list produced is a list of `int`s.

Four new tests have also been included. These tests ensure that
we are generating srcsets i.a.w. the rest of the SDK.