### PR TITLE
refactor: convert tol to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default, srcset width `tol`erance is set to 8 percent, which we consider to b
 ```python
 >>> import imgix
 >>> ub = imgix.UrlBuilder('demo.imgix.net', include_library_param=False)
->>> srcset = ub.create_srcset('image.jpg', start=100, stop=384, tol=20)
+>>> srcset = ub.create_srcset('image.jpg', start=100, stop=384, tol=0.20)
 
 ```
 
@@ -233,7 +233,7 @@ The `target_widths` function is used internally to generate lists of target widt
 It is a way to generate, play with, and explore different target widths separately from srcset attributes. One way of generating a srcset attribute is:
 
 ```python
-srcset = ub.create_srcset('image.jpg', start=300, stop=3000, tol=13)
+srcset = ub.create_srcset('image.jpg', start=300, stop=3000, tol=0.13)
 ```
 
 The above is convenient if `start`, `stop`, and `tol`erance are known in advance. Another approach is to use `target_widths` to determine which combination of values for `start`, `stop`, and `tol`erance work best.
@@ -241,7 +241,7 @@ The above is convenient if `start`, `stop`, and `tol`erance are known in advance
 ```python
 >>> from imgix import UrlBuilder, target_widths
 >>> # Create
->>> widths = target_widths(300, 3000, 13)
+>>> widths = target_widths(300, 3000, 0.13)
 >>> widths
 [300, 378, 476, 600, 756, 953, 1200, 1513, 1906, 2401, 3000]
 >>> # Explore

--- a/imgix/constants.py
+++ b/imgix/constants.py
@@ -10,10 +10,10 @@ DOMAIN_PATTERN = re.compile(
 # difference between an image's downloaded size and its rendered size.
 # For example, setting this value to 10 means that an image will not
 # render more than 10% larger or smaller than its native size.
-SRCSET_WIDTH_TOLERANCE = 8
+SRCSET_WIDTH_TOLERANCE = 0.08
 
 # The minimum srcset width tolerance.
-SRCSET_MIN_WIDTH_TOLERANCE = 1
+SRCSET_MIN_WIDTH_TOLERANCE = 0.01
 
 # The default srcset target ratios.
 SRCSET_DPR_TARGET_RATIOS = range(1, 6)

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -158,7 +158,7 @@ class UrlBuilder(object):
             Starting minimum width value, MIN_WIDTH by default.
         stop : int, optional
             Stopping maximum width value, MAX_WIDTH by default.
-        tol : int, optional
+        tol : float, optional
             Tolerable amount of width value variation, TOLERANCE by default.
         widths: list, optional
             List of target widths, `TARGET_WIDTHS` by default.
@@ -284,7 +284,7 @@ def target_widths(start=MIN_WIDTH, stop=MAX_WIDTH, tol=TOLERANCE):
         Starting minimum width value, MIN_WIDTH by default.
     stop : int, optional
         Stopping maximum width value, MAX_WIDTH by default.
-    tol : int, optional
+    tol : float, optional
         Tolerable amount of image width-variation, TOLERANCE by default.
 
     Returns
@@ -307,7 +307,7 @@ def target_widths(start=MIN_WIDTH, stop=MAX_WIDTH, tol=TOLERANCE):
 
     while start < stop and start < MAX_WIDTH:
         resolutions.append(int(round(start)))
-        start *= 1 + (tol / 100.0) * 2
+        start *= 1 + tol * 2
 
     # The most recently appended value may, or may not, be
     # the `stop` value. In order to be inclusive of the

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -106,18 +106,18 @@ def validate_width_tol(value):
     Validate the width tolerance.
 
     This function ensures that the width tolerance `value` is  greater than or
-    equal to 1, where 1 represents a width tolerance of 1%.
+    equal to 0.01, where 0.01 represents a width tolerance of 1%.
 
-    Note: `value` can be either a float or an int, but this is only to yield
-    flexibility to the caller.
+    Note: `value` can be either a float or an int (in the case of 1.0 or 100%),
+    but this is only to yield flexibility to the caller.
 
     Parameters
     ----------
     value : float, int
-        Numerical value, typically within the range of [1, 100]. It can be
-        greater than 100, but no less than 1.
+        Numerical value, typically within the range of [0.01, 1]. It can be
+        greater than 1, but no less than 0.01.
     """
-    invalid_tol_error = 'tolerance `value` must be a positive numerical value'
+    invalid_tol_error = 'tolerance `value` must be >= 0.01'
     assert isinstance(value, (float, int)), invalid_tol_error
     assert ONE_PERCENT <= value, invalid_tol_error
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -26,7 +26,7 @@ def test_readme_500_to_2000():
 
 def test_readme_100_to_384_at_20():
     ub = UrlBuilder(DOMAIN, include_library_param=False)
-    actual = ub.create_srcset(JPG_PATH, start=100, stop=384, tol=20)
+    actual = ub.create_srcset(JPG_PATH, start=100, stop=384, tol=0.20)
     expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
         "https://testing.imgix.net/image.jpg?w=140 140w,\n" + \
         "https://testing.imgix.net/image.jpg?w=196 196w,\n" + \

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -100,7 +100,7 @@ def test_create_srcset_2257_to_4087():
 def test_create_srcset_100_to_108():
     # Test that `tol=1` produces the correct spread.
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
-    actual = ub.create_srcset(JPG_PATH, start=100, stop=108, tol=1)
+    actual = ub.create_srcset(JPG_PATH, start=100, stop=108, tol=0.01)
     expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
         "https://testing.imgix.net/image.jpg?w=102 102w,\n" + \
         "https://testing.imgix.net/image.jpg?w=104 104w,\n" + \


### PR DESCRIPTION
Prior to this PR, width `tol`erance was expected to be of type `int`
and within the range of `[1, 100]` or "one to one hundred percent."
Now, `tol` is expected to be a `float` in the range `[0.01, 1.0]` which
also represents "one to one hundred percent."

We have done this for consistency purposes, i.e. [imgix-core-js](https://github.com/imgix/imgix-core-js/blob/2c9d97a7ab54c7a8fec378732bdcb855cef41907/src/imgix-core-js.js#L25) uses
floating point values. Since `imgix-core-js` was impl'd first, we defer
to this tried/tested interface. This way, this feature is standard
and consistent kit-wide.