### PR TITLE
refactor: throw exceptions from validators

### DIFF
--- a/imgix/errors.py
+++ b/imgix/errors.py
@@ -1,0 +1,25 @@
+class Error(Exception):
+    """Base class for exceptions in the imgix module."""
+
+    def __init__(self, message):
+        """Initialize the `Error` with a `message` explaining why the
+        exception occurred.
+
+        Parameters
+        ----------
+        message : str
+            A brief description explaining why the exception occurred.
+        """
+        self.message = message
+
+
+class DomainError(Error):
+    """Exception raised for an invalid domain string."""
+
+
+class WidthRangeError(Error):
+    """Exception raised for an invalid width range."""
+
+
+class WidthToleranceError(Error):
+    """Exception raised for an invalid width `tol`erance."""

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -7,7 +7,7 @@ from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
 from .constants import IMAGE_MIN_WIDTH as MIN_WIDTH
 from .constants import SRCSET_WIDTH_TOLERANCE as TOLERANCE
 from .constants import DPR_QUALITIES
-from .validators import validate_min_max_tol
+from .validators import validate_min_max_tol, validate_widths
 from .urlhelper import UrlHelper
 
 
@@ -167,9 +167,10 @@ class UrlBuilder(object):
         str
             Srcset attribute string.
         """
-        targets_list = kwargs.get('widths', None)
-        if targets_list:
-            return self._build_srcset_pairs(path, params, targets=targets_list)
+        widths_list = kwargs.get('widths', None)
+        if widths_list:
+            validate_widths(widths_list)
+            return self._build_srcset_pairs(path, params, targets=widths_list)
 
         # Attempt to assign `start`, `stop`, and `tol` from `kwargs`.
         # If the key does not exist, assign `None`.

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -177,25 +177,21 @@ class UrlBuilder(object):
         stop = kwargs.get('stop', None)
         tol = kwargs.get('tol', None)
 
-        # Attempt to generated the target widths specified.
+        # Attempt to generate the specified target widths.
         # Assign defaults where appropriate, then validate
         # this group. If validation succeeds, generate the
         # target widths.
-        generated_targets = None
-        if start or stop or tol:
-            _start = start or MIN_WIDTH
-            _stop = stop or MAX_WIDTH
-            _tol = tol or TOLERANCE
+        if start is None:
+            start = MIN_WIDTH
+        if stop is None:
+            stop = MAX_WIDTH
+        if tol is None:
+            tol = TOLERANCE
 
-            validate_min_max_tol(_start, _stop, _tol)
+        validate_min_max_tol(start, stop, tol)
 
-            generated_targets = \
-                target_widths(start=_start, stop=_stop, tol=_tol)
-
-        # If `generated_targets` have been assigned, use these
-        # targets. Otherwise, no target widths have been generated
-        # and we must assign the default target widths.
-        targets = generated_targets or TARGET_WIDTHS
+        targets = \
+            target_widths(start=start, stop=stop, tol=tol)
 
         if (self._is_dpr(params)):
             disable_variable_quality = \

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -223,7 +223,7 @@ class UrlBuilder(object):
         # quality values, 'q', will vary in accordance with the
         # default `DPR_QUALITIES` [1x => q=75, ... 5x => 20].
         #
-        # If 'q' is explicitly passed, it takes precendence over
+        # If 'q' is explicitly passed, it takes precedence over
         # the default `DPR_QUALITIES`. Right now, this means that
         # if 'q' is passed, it's value will be used for the output
         # quality of each dpr image (i.e. for 1x through 5x).

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -1,3 +1,4 @@
+from .errors import WidthRangeError, WidthToleranceError
 from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
 from .constants import IMAGE_ZERO_WIDTH as ZERO_WIDTH
 from .constants import SRCSET_MIN_WIDTH_TOLERANCE as ONE_PERCENT
@@ -27,12 +28,14 @@ def validate_min_width(value):
     value : float, int
         A valid `value` must be a positive numerical value.
     """
-    invalid_width_error = '`min_width` must be a positive ' \
+    invalid_width_type_error = '`start` width must be a positive ' \
         '`float` or `int`'
-    assert isinstance(value, (float, int)), invalid_width_error
+    if not isinstance(value, (float, int)):
+        raise WidthRangeError(invalid_width_type_error)
 
-    invalid_min_error = '`min_width` must be greater than zero'
-    assert value > ZERO_WIDTH, invalid_min_error
+    invalid_min_error = '`start` width must be greater than zero'
+    if not value > ZERO_WIDTH:
+        raise WidthRangeError(invalid_min_error)
 
 
 def validate_max_width(value):
@@ -61,12 +64,16 @@ def validate_max_width(value):
     value : float, int
         A valid `value` must be a positive numerical value.
     """
-    invalid_width_error = '`max_width` must be a positive ' \
+    invalid_width_error = '`stop` width value must be a positive ' \
         '`float` or `int`'
-    assert isinstance(value, (float, int)), invalid_width_error
+    if not isinstance(value, (float, int)):
+        raise WidthRangeError(invalid_width_error)
 
-    invalid_max_error = '`max_width` must be <= 8192.0'
-    assert ZERO_WIDTH < value <= MAX_WIDTH, invalid_max_error
+    invalid_max_error = \
+        '`stop` width value must be > 0 && <= `constants.IMAGE_MAX_WIDTH`'
+
+    if not ZERO_WIDTH < value <= MAX_WIDTH:
+        raise WidthRangeError(invalid_max_error)
 
 
 def validate_range(min_width, max_width):
@@ -97,8 +104,9 @@ def validate_range(min_width, max_width):
     validate_min_width(min_width)
     validate_max_width(max_width)
 
-    invalid_range_error = '`min_width` must be less than `max_width`'
-    assert min_width <= max_width, invalid_range_error
+    invalid_range_error = '`start` width must be less than `stop` width'
+    if not min_width <= max_width:
+        raise WidthRangeError(invalid_range_error)
 
 
 def validate_width_tol(value):
@@ -117,9 +125,12 @@ def validate_width_tol(value):
         Numerical value, typically within the range of [0.01, 1]. It can be
         greater than 1, but no less than 0.01.
     """
-    invalid_tol_error = 'tolerance `value` must be >= 0.01'
-    assert isinstance(value, (float, int)), invalid_tol_error
-    assert ONE_PERCENT <= value, invalid_tol_error
+    invalid_tol_error = '`tol`erance value must be >= 0.01'
+    if not isinstance(value, (float, int)):
+        raise WidthToleranceError(invalid_tol_error)
+
+    if not ONE_PERCENT <= value:
+        raise WidthToleranceError(invalid_tol_error)
 
 
 def validate_min_max_tol(min_width, max_width, tol):

--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -152,3 +152,33 @@ def validate_min_max_tol(min_width, max_width, tol):
     """
     validate_range(min_width, max_width)
     validate_width_tol(tol)
+
+
+def validate_widths(width_values):
+    """Validate a list of `width_values`.
+
+    This function checks that a list of `width_values` is non-empty and that
+    no width value is negative.
+
+
+    Parameters
+    ----------
+    values : list
+        A list of width values, typically target width values.
+
+    Raises
+    ------
+    WidthRangeError
+        If the list of `width_values` is empty or `None`, raise.
+    WidthRangeError
+        If any width value within the list is negative, raise.
+    """
+    if not isinstance(width_values, list):
+        raise WidthRangeError('`width_values` must be a `list`')
+
+    if not width_values:
+        raise WidthRangeError('`width_values` cannot be `None` or `[]`')
+
+    any_width_is_negative = any([w for w in width_values if w < 0])
+    if any_width_is_negative:
+        raise WidthRangeError('`width_values` cannot be negative')

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import imgix
+import unittest
 import hashlib
 import re
 
+from imgix.errors import WidthRangeError, WidthToleranceError
 from imgix.constants import DPR_QUALITIES
 from imgix.constants import SRCSET_TARGET_WIDTHS as TARGET_WIDTHS
 from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH
@@ -360,3 +362,15 @@ def test_given_width_params_not_altered():
     _default_srcset(params)
 
     assert params == {'w': 100}
+
+
+class TestSrcsetRaises(unittest.TestCase):
+    def test_start_0_raises(self):
+        ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+        with self.assertRaises(WidthRangeError):
+            ub.create_srcset(JPG_PATH, start=0)
+
+    def test_tol_0_raises(self):
+        ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+        with self.assertRaises(WidthToleranceError):
+            ub.create_srcset(JPG_PATH, tol=0)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,7 +4,7 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
     IMAGE_ZERO_WIDTH, SRCSET_MIN_WIDTH_TOLERANCE
 
 from imgix.validators import validate_min_width, validate_max_width, \
-    validate_range, validate_min_max_tol
+    validate_range, validate_min_max_tol, validate_widths
 
 from imgix.errors import WidthRangeError, WidthToleranceError
 
@@ -75,3 +75,7 @@ class TestValidators(unittest.TestCase):
         for x, y in enumerate([x for x in range(1, 10)], start=1):
             assert x == y
             validate_range(x, y)
+
+    def test_validate_widths_raise(self):
+        with self.assertRaises(WidthRangeError):
+            validate_widths([2, 3, 4, 5, 6, -7])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -6,52 +6,54 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
 from imgix.validators import validate_min_width, validate_max_width, \
     validate_range, validate_min_max_tol
 
+from imgix.errors import WidthRangeError, WidthToleranceError
+
 
 class TestValidators(unittest.TestCase):
 
     def test_validate_min_raises(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_min_width(-1)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_min_width("1")
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_min_width(IMAGE_ZERO_WIDTH)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_min_width([-1])
 
     def test_validate_max_raises(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_max_width(-1)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_max_width("1")
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_max_width(IMAGE_ZERO_WIDTH)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_max_width([-1])
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_max_width(IMAGE_MAX_WIDTH+1)
 
     def test_validate_range_raises(self):
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_range(IMAGE_ZERO_WIDTH, IMAGE_ZERO_WIDTH)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_range(IMAGE_ZERO_WIDTH, IMAGE_MAX_WIDTH)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthRangeError):
             validate_range(IMAGE_MAX_WIDTH, IMAGE_MIN_WIDTH)
 
     def test_validate_min_max_tol_raises(self):
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(WidthToleranceError):
             # `IMAGE_ZERO_WIDTH` is being used to
             # simulate a `tol` < ONE_PERCENT.
             validate_min_max_tol(


### PR DESCRIPTION
The purpose of this PR is to complete our validation implementation.
The two exceptions used throughout this PR are:

- `WidthRangeError`: for invalid `start` or `stop` width values
- `WidthToleranceError`: for invalid width `tol`erance values.

An example of the output when an exception _is thrown_ is:
```python
from imgix import UrlBuilder
u = UrlBuilder("a.b.c", include_library_param=False)
u.create_srcset('image.png', start=1, stop=0)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "imgix-python/imgix/urlbuilder.py", line 191, in create_srcset
    validate_min_max_tol(start, stop, tol)
  File "imgix-python/imgix/validators.py", line 153, in validate_min_max_tol
    validate_range(min_width, max_width)
  File "imgix-python/imgix/validators.py", line 105, in validate_range
    validate_max_width(max_width)
  File "imgix-python/imgix/validators.py", line 76, in validate_max_width
    raise WidthRangeError(invalid_max_error)
imgix.errors.WidthRangeError: `stop` width value must be > 0 && <= `constants.IMAGE_MAX_WIDTH`
```

W.r.t. the above, both `start` and `stop` are individually validated; once
they pass their individual validation steps, the range is checked (ie. that
`start <= stop`. This is why the above throws a `WidthRangeError` instead
of a `WidthToleranceError`.

```python
u.create_srcset('image.png', start=100, stop=200, tol=0.001)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "imgix-python/imgix/urlbuilder.py", line 191, in create_srcset
    validate_min_max_tol(start, stop, tol)
  File "imgix-python/imgix/validators.py", line 154, in validate_min_max_tol
    validate_width_tol(tol)
  File "imgix-python/imgix/validators.py", line 133, in validate_width_tol
    raise WidthToleranceError(invalid_tol_error)
imgix.errors.WidthToleranceError: `tol`erance value must be >= 0.01
```

In completing this validation, lines `184-189 of imgix/urlbuilder.py` have
been revised to account for `0` being considered falsy. 