### PR TITLE
refactor: relax validation for max width values

### DIFF
--- a/imgix/validators.py
+++ b/imgix/validators.py
@@ -1,5 +1,4 @@
 from .errors import WidthRangeError, WidthToleranceError
-from .constants import IMAGE_MAX_WIDTH as MAX_WIDTH
 from .constants import IMAGE_ZERO_WIDTH as ZERO_WIDTH
 from .constants import SRCSET_MIN_WIDTH_TOLERANCE as ONE_PERCENT
 
@@ -33,7 +32,8 @@ def validate_min_width(value):
     if not isinstance(value, (float, int)):
         raise WidthRangeError(invalid_width_type_error)
 
-    invalid_min_error = '`start` width must be greater than zero'
+    invalid_min_error = \
+        '`start` width must be greater than, or equal to, zero'
     if not value > ZERO_WIDTH:
         raise WidthRangeError(invalid_min_error)
 
@@ -70,9 +70,9 @@ def validate_max_width(value):
         raise WidthRangeError(invalid_width_error)
 
     invalid_max_error = \
-        '`stop` width value must be > 0 && <= `constants.IMAGE_MAX_WIDTH`'
+        '`stop` width value must be greater than, or equal to, zero'
 
-    if not ZERO_WIDTH < value <= MAX_WIDTH:
+    if not ZERO_WIDTH <= value:
         raise WidthRangeError(invalid_max_error)
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,9 +8,10 @@ from imgix.validators import validate_min_width, validate_max_width, \
 
 from imgix.errors import WidthRangeError, WidthToleranceError
 
+LESS_THAN_ZERO = IMAGE_ZERO_WIDTH - 1
+
 
 class TestValidators(unittest.TestCase):
-
     def test_validate_min_raises(self):
         with self.assertRaises(WidthRangeError):
             validate_min_width(-1)
@@ -19,7 +20,7 @@ class TestValidators(unittest.TestCase):
             validate_min_width("1")
 
         with self.assertRaises(WidthRangeError):
-            validate_min_width(IMAGE_ZERO_WIDTH)
+            validate_min_width(LESS_THAN_ZERO)
 
         with self.assertRaises(WidthRangeError):
             validate_min_width([-1])
@@ -32,13 +33,10 @@ class TestValidators(unittest.TestCase):
             validate_max_width("1")
 
         with self.assertRaises(WidthRangeError):
-            validate_max_width(IMAGE_ZERO_WIDTH)
+            validate_max_width(LESS_THAN_ZERO)
 
         with self.assertRaises(WidthRangeError):
             validate_max_width([-1])
-
-        with self.assertRaises(WidthRangeError):
-            validate_max_width(IMAGE_MAX_WIDTH+1)
 
     def test_validate_range_raises(self):
 


### PR DESCRIPTION
This PR relaxes the constraints on max width values. Prior to this PR
max width values were bounded, now they are not. The only restriction
is that image width values (both max and min) be greater than or equal
to zero (and that the max value is not less than the min value).