### PR TITLE
chore: change refs of master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ tox -e p27-compat  # Python 2.7 with future compatibility aliases
 Publishing to PyPI
 ------------------
 
-To publish a new version of the package to PyPI, increment the version in [imgix/__init__.py](https://github.com/imgix/imgix-python/blob/master/imgix/__init__.py) run the following:
+To publish a new version of the package to PyPI, increment the version in [imgix/__init__.py](https://github.com/imgix/imgix-python/blob/main/imgix/__init__.py) run the following:
 
 ```bash
 pip install wheel

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 `imgix-python` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 [![Version](https://img.shields.io/pypi/v/imgix.svg)](https://pypi.org/project/imgix/)
-[![Build Status](https://travis-ci.org/imgix/imgix-python.svg?branch=master)](https://travis-ci.org/imgix/imgix-python)
+[![Build Status](https://travis-ci.org/imgix/imgix-python.svg?branch=main)](https://travis-ci.org/imgix/imgix-python)
 ![Downloads](https://img.shields.io/pypi/dm/imgix)
 ![Python Versions](https://img.shields.io/pypi/pyversions/imgix)
-[![License](https://img.shields.io/github/license/imgix/imgix-python)](https://github.com/imgix/imgix-python/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/imgix/imgix-python)](https://github.com/imgix/imgix-python/blob/main/LICENSE)
 
 ---
 <!-- /ix-docs-ignore -->


### PR DESCRIPTION
This PR changes any references from the master branch to the main branch, now that it is the default.