### PR TITLE
feat: add functionality to optionally disable path encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 
 python:
   - 3.6
-  - 3.7
-  - 3.8
+  # TODO: re-enable these tests once the importlib_metadata version bug has
+  # been addressed
+  # - 3.7
+  # - 3.8
   - pypy3
 
 env:

--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ Path encoding is enabled by default. It can be toggled off by setting `disable_p
 
 ```python
 >>> from imgix import UrlBuilder
->>> ub = UrlBuilder("demo.imgix.net", disable_path_encoding=True)
->>> ub.create_url("file+with%20some+crazy?things.jpg", {'w': 100, 'h': 100})  
-'https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100'
+>>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
+>>> >>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
+'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
 ```
 
-Normally this would output a src of `https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100`, but since path encoding is disabled, it will output a src of `https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100`.
+Normally this would output a source URL like `https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25.jpg?h=100&2=100`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100`.
+
 
 ## Srcset Generation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [Signed URLs](#signed-urls)
+- [Disabled Path Encoding](#disabled-path-encoding)
 - [Srcset Generation](#srcset-generation)
     * [Fixed-Width Images](#fixed-width-images)
         + [Variable Quality](#variable-quality)
@@ -68,6 +69,19 @@ To produce a signed URL, you must enable secure URLs on your source and then pro
 'https://demo.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4'
 
 ```
+
+## Disabled Path Encoding
+
+Path encoding is enabled by default. It can be toggled off by setting `disable_path_encoding` to `True`:
+
+```python
+>>> from imgix import UrlBuilder
+>>> ub = UrlBuilder("demo.imgix.net", disable_path_encoding=True)
+>>> ub.create_url("file+with%20some+crazy?things.jpg", {'w': 100, 'h': 100})  
+'https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100'
+```
+
+Normally this would output a src of `https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100`, but since path encoding is disabled, it will output a src of `https://demo.imgix.net/file+with%20some+crazy?things.jpg?h=100&w=100`.
 
 ## Srcset Generation
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Path encoding is enabled by default. It can be toggled off by setting `disable_p
 ```python
 >>> from imgix import UrlBuilder
 >>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
->>> >>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
+>>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
 'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
 ```
 

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -137,12 +137,12 @@ class UrlBuilder(object):
 
         # Encode the path without a leading forward slash,
         # then add it back before returning.
-        if not self._disable_path_encoding:
-            if _path.startswith("http"):
-                return "/" + self._encode_proxy_path(_path)
-            else:
-                return "/" + self._encode_file_path(_path)
-        return "/" + _path
+        if self._disable_path_encoding:
+            return "/" + _path
+        elif _path.startswith("http"):
+            return "/" + self._encode_proxy_path(_path)
+        else:
+            return "/" + self._encode_file_path(_path)
 
     def _encode_file_path(self, path):
         return quote(path, safe="/&$;=@,")

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -137,7 +137,7 @@ class UrlBuilder(object):
 
         # Encode the path without a leading forward slash,
         # then add it back before returning.
-        if self._disable_path_encoding == False:
+        if not self._disable_path_encoding:
             if _path.startswith("http"):
                 return "/" + self._encode_proxy_path(_path)
             else:

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -37,6 +37,8 @@ class UrlBuilder(object):
     include_library_param : bool
         If `True`, each created URL is suffixed with 'ixlib' parameter
         indicating the library used for generating the URLs. (default `True`)
+    disable_path_encoding : bool
+        If `True`, the path component of the URL will not be encoded. (default `False`)
 
     Methods
     -------
@@ -58,7 +60,8 @@ class UrlBuilder(object):
             domain,
             use_https=True,
             sign_key=None,
-            include_library_param=True):
+            include_library_param=True,
+            disable_path_encoding=False):
 
         self.validate_domain(domain)
 
@@ -66,6 +69,7 @@ class UrlBuilder(object):
         self._sign_key = sign_key
         self._use_https = use_https
         self._include_library_param = include_library_param
+        self._disable_path_encoding = disable_path_encoding
 
     def validate_domain(self, domain):
         """
@@ -133,10 +137,12 @@ class UrlBuilder(object):
 
         # Encode the path without a leading forward slash,
         # then add it back before returning.
-        if _path.startswith("http"):
-            return "/" + self._encode_proxy_path(_path)
-        else:
-            return "/" + self._encode_file_path(_path)
+        if self._disable_path_encoding == False:
+            if _path.startswith("http"):
+                return "/" + self._encode_proxy_path(_path)
+            else:
+                return "/" + self._encode_file_path(_path)
+        return "/" + _path
 
     def _encode_file_path(self, path):
         return quote(path, safe="/&$;=@,")

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -2,59 +2,68 @@
 
 from imgix import UrlBuilder
 
-DOMAIN = 'testing.imgix.net'
-TOKEN = 'MYT0KEN'
-JPG_PATH = 'image.jpg'
+DOMAIN = "testing.imgix.net"
+TOKEN = "MYT0KEN"
+JPG_PATH = "image.jpg"
 
 
 def test_readme_500_to_2000():
     ub = UrlBuilder(DOMAIN, include_library_param=False)
     actual = ub.create_srcset(JPG_PATH, start=500, stop=2000)
-    expected = "https://testing.imgix.net/image.jpg?w=500 500w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=580 580w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=673 673w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=780 780w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=905 905w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=1050 1050w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=1218 1218w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=1413 1413w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=1639 1639w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=1901 1901w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=2000 2000w"
-    assert (expected == actual)
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=500 500w,\n"
+        + "https://testing.imgix.net/image.jpg?w=580 580w,\n"
+        + "https://testing.imgix.net/image.jpg?w=673 673w,\n"
+        + "https://testing.imgix.net/image.jpg?w=780 780w,\n"
+        + "https://testing.imgix.net/image.jpg?w=905 905w,\n"
+        + "https://testing.imgix.net/image.jpg?w=1050 1050w,\n"
+        + "https://testing.imgix.net/image.jpg?w=1218 1218w,\n"
+        + "https://testing.imgix.net/image.jpg?w=1413 1413w,\n"
+        + "https://testing.imgix.net/image.jpg?w=1639 1639w,\n"
+        + "https://testing.imgix.net/image.jpg?w=1901 1901w,\n"
+        + "https://testing.imgix.net/image.jpg?w=2000 2000w"
+    )
+    assert expected == actual
 
 
 def test_readme_100_to_384_at_20():
     ub = UrlBuilder(DOMAIN, include_library_param=False)
     actual = ub.create_srcset(JPG_PATH, start=100, stop=384, tol=0.20)
-    expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=140 140w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=196 196w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=274 274w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=384 384w"
-    assert (expected == actual)
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=100 100w,\n"
+        + "https://testing.imgix.net/image.jpg?w=140 140w,\n"
+        + "https://testing.imgix.net/image.jpg?w=196 196w,\n"
+        + "https://testing.imgix.net/image.jpg?w=274 274w,\n"
+        + "https://testing.imgix.net/image.jpg?w=384 384w"
+    )
+    assert expected == actual
 
 
 def test_readme_custom_widths():
     builder = UrlBuilder(DOMAIN, include_library_param=False)
     actual = builder.create_srcset(JPG_PATH, widths=[144, 240, 320, 446, 640])
-    expected = "https://testing.imgix.net/image.jpg?w=144 144w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=240 240w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=320 320w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=446 446w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=640 640w"
-    assert (expected == actual)
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=144 144w,\n"
+        + "https://testing.imgix.net/image.jpg?w=240 240w,\n"
+        + "https://testing.imgix.net/image.jpg?w=320 320w,\n"
+        + "https://testing.imgix.net/image.jpg?w=446 446w,\n"
+        + "https://testing.imgix.net/image.jpg?w=640 640w"
+    )
+    assert expected == actual
 
 
 def test_readme_variable_quality():
     builder = UrlBuilder(DOMAIN, include_library_param=False)
 
     actual = builder.create_srcset(
-        JPG_PATH, params={"w": 100}, disable_variable_quality=False)
+        JPG_PATH, params={"w": 100}, disable_variable_quality=False
+    )
 
-    expected = "https://testing.imgix.net/image.jpg?dpr=1&q=75&w=100 1x,\n" + \
-        "https://testing.imgix.net/image.jpg?dpr=2&q=50&w=100 2x,\n" + \
-        "https://testing.imgix.net/image.jpg?dpr=3&q=35&w=100 3x,\n" + \
-        "https://testing.imgix.net/image.jpg?dpr=4&q=23&w=100 4x,\n" + \
-        "https://testing.imgix.net/image.jpg?dpr=5&q=20&w=100 5x"
-    assert (expected == actual)
+    expected = (
+        "https://testing.imgix.net/image.jpg?dpr=1&q=75&w=100 1x,\n"
+        + "https://testing.imgix.net/image.jpg?dpr=2&q=50&w=100 2x,\n"
+        + "https://testing.imgix.net/image.jpg?dpr=3&q=35&w=100 3x,\n"
+        + "https://testing.imgix.net/image.jpg?dpr=4&q=23&w=100 4x,\n"
+        + "https://testing.imgix.net/image.jpg?dpr=5&q=20&w=100 5x"
+    )
+    assert expected == actual

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -11,9 +11,10 @@ from imgix.constants import SRCSET_TARGET_WIDTHS as TARGET_WIDTHS
 from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH
 
 
-DOMAIN = "testing.imgix.net"
-TOKEN = "MYT0KEN"
-JPG_PATH = "image.jpg"
+DOMAIN = 'testing.imgix.net'
+TOKEN = 'MYT0KEN'
+JPG_PATH = 'image.jpg'
+JPG_PATH_WITH_SPACE = 'image 123.jpg'
 
 
 def extract_descriptors(srcset=""):
@@ -130,6 +131,21 @@ def test_create_srcset_100_to_108():
     )
 
     assert expected == actual
+
+def test_create_srcset_with_widths_and_disable_path_encoding_true():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, widths=[100])
+    expected = "https://testing.imgix.net/image 123.jpg?w=100 100w"
+
+    assert(expected == actual)
+
+
+def test_create_srcset_start_equals_stop_with_disable_path_encoding_true():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, start=713, stop=713)
+    expected = "https://testing.imgix.net/image 123.jpg?w=713 713w"
+
+    assert(expected == actual)
 
 
 def test_given_width_srcset_is_DPR():

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -11,9 +11,9 @@ from imgix.constants import SRCSET_TARGET_WIDTHS as TARGET_WIDTHS
 from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH
 
 
-DOMAIN = 'testing.imgix.net'
-TOKEN = 'MYT0KEN'
-JPG_PATH = 'image.jpg'
+DOMAIN = "testing.imgix.net"
+TOKEN = "MYT0KEN"
+JPG_PATH = "image.jpg"
 
 
 def extract_descriptors(srcset=""):
@@ -25,14 +25,15 @@ def extract_descriptors(srcset=""):
             return split_url[1].replace(",", "")
         else:
             return ""
+
     split_srcset = srcset.split("\n")
     return [extract_descriptor(u) for u in split_srcset]
 
 
 def _default_srcset(params={}):
-    ub = imgix.UrlBuilder(domain=DOMAIN,
-                          sign_key=TOKEN,
-                          include_library_param=False)
+    ub = imgix.UrlBuilder(
+        domain=DOMAIN, sign_key=TOKEN, include_library_param=False
+    )
     return ub.create_srcset(JPG_PATH, params)
 
 
@@ -41,55 +42,57 @@ def _parse_width(width):
 
 
 def get_params(url):
-    return url[url.index('?'): url.index('s=') - 1]
+    return url[url.index("?"): url.index("s=") - 1]
 
 
 def make_signature_base(params):
-    return TOKEN + '/' + JPG_PATH + params
+    return TOKEN + "/" + JPG_PATH + params
 
 
 def make_expected_signature(url):
     params = get_params(url)
     base = make_signature_base(params)
-    return hashlib.md5(base.encode('utf-8')).hexdigest()
+    return hashlib.md5(base.encode("utf-8")).hexdigest()
 
 
 def get_actual_signature(url):
-    return url[url.index('s=') + 2: len(url)]
+    return url[url.index("s=") + 2: len(url)]
 
 
 def test_no_parameters_generates_srcset_pairs():
     srcset = _default_srcset()
     expected_number_of_pairs = 31
-    assert(expected_number_of_pairs == len(srcset.split(',')))
+    assert expected_number_of_pairs == len(srcset.split(","))
 
 
 def test_srcset_pair_values():
     # array of expected resolutions to be generated
     resolutions = TARGET_WIDTHS
     srcset = _default_srcset()
-    srclist = srcset.split(',')
+    srclist = srcset.split(",")
     index = 0
 
     for src in srclist:
-        width = src.split(' ')[1]
+        width = src.split(" ")[1]
 
         # extract width int values
-        value = re.search(re.compile(r'\d+'), width)
-        assert(int(value.group(0)) == resolutions[index])
+        value = re.search(re.compile(r"\d+"), width)
+        assert int(value.group(0)) == resolutions[index]
         index += 1
 
 
 def test_create_srcset_with_widths():
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
     actual = ub.create_srcset(JPG_PATH, widths=[100, 200, 300, 400, 500])
-    expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=200 200w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=300 300w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=400 400w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=500 500w"
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=100 100w,\n"
+        + "https://testing.imgix.net/image.jpg?w=200 200w,\n"
+        + "https://testing.imgix.net/image.jpg?w=300 300w,\n"
+        + "https://testing.imgix.net/image.jpg?w=400 400w,\n"
+        + "https://testing.imgix.net/image.jpg?w=500 500w"
+    )
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_create_srcset_start_equals_stop():
@@ -97,58 +100,62 @@ def test_create_srcset_start_equals_stop():
     actual = ub.create_srcset(JPG_PATH, start=713, stop=713)
     expected = "https://testing.imgix.net/image.jpg?w=713 713w"
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_create_srcset_2257_to_4087():
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
     actual = ub.create_srcset(JPG_PATH, start=2257, stop=4087)
-    expected = "https://testing.imgix.net/image.jpg?w=2257 2257w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=2618 2618w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=3037 3037w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=3523 3523w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=4087 4087w"
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=2257 2257w,\n"
+        + "https://testing.imgix.net/image.jpg?w=2618 2618w,\n"
+        + "https://testing.imgix.net/image.jpg?w=3037 3037w,\n"
+        + "https://testing.imgix.net/image.jpg?w=3523 3523w,\n"
+        + "https://testing.imgix.net/image.jpg?w=4087 4087w"
+    )
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_create_srcset_100_to_108():
     # Test that `tol=1` produces the correct spread.
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
     actual = ub.create_srcset(JPG_PATH, start=100, stop=108, tol=0.01)
-    expected = "https://testing.imgix.net/image.jpg?w=100 100w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=102 102w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=104 104w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=106 106w,\n" + \
-        "https://testing.imgix.net/image.jpg?w=108 108w"
+    expected = (
+        "https://testing.imgix.net/image.jpg?w=100 100w,\n"
+        + "https://testing.imgix.net/image.jpg?w=102 102w,\n"
+        + "https://testing.imgix.net/image.jpg?w=104 104w,\n"
+        + "https://testing.imgix.net/image.jpg?w=106 106w,\n"
+        + "https://testing.imgix.net/image.jpg?w=108 108w"
+    )
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_given_width_srcset_is_DPR():
-    srcset = _default_srcset({'w': 100})
+    srcset = _default_srcset({"w": 100})
     device_pixel_ratio = 1
-    srclist = srcset.split(',')
+    srclist = srcset.split(",")
 
     for src in srclist:
-        ratio = src.split(' ')[1]
-        dpr_str = str(device_pixel_ratio) + 'x'
-        assert(dpr_str == ratio)
+        ratio = src.split(" ")[1]
+        dpr_str = str(device_pixel_ratio) + "x"
+        assert dpr_str == ratio
         device_pixel_ratio += 1
 
 
 def test_given_width_srcset_has_dpr_params():
-    srcset = _default_srcset({'w': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"w": 100})
+    srclist = srcset.split(",")
 
     for i in range(len(srclist)):
-        src = srclist[i].split(' ')[0]
-        assert(src.index("dpr=" + str(i+1)))
+        src = srclist[i].split(" ")[0]
+        assert src.index("dpr=" + str(i + 1))
 
 
 def test_variable_output_quality_default():
-    srcset = _default_srcset({'w': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"w": 100})
+    srclist = srcset.split(",")
 
     # Accumulate the values of the `DPR_QUALITIES` dictionary
     # as a `dpr_qualities` list.
@@ -158,200 +165,200 @@ def test_variable_output_quality_default():
     # we expect them to occur in.
     for src, dpr_quality in zip(srclist, dpr_qualities):
         quality = "q=" + str(dpr_quality)
-        assert(quality in src)
+        assert quality in src
 
 
 def test_disable_variable_output_quality():
     ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
     srcset = ub.create_srcset(JPG_PATH, disable_variable_quality=True)
-    srclist = srcset.split(',')
+    srclist = srcset.split(",")
 
     dpr_qualities = sorted([q for q in DPR_QUALITIES.values()], reverse=True)
 
     for src, dpr_quality in zip(srclist, dpr_qualities):
         quality = "q=" + str(dpr_quality)
         # Ensure we _do not_ find variable qualities in each src.
-        assert(not (quality in src))
+        assert not (quality in src)
 
 
 def test_given_width_signs_urls():
-    srcset = _default_srcset({'w': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"w": 100})
+    srclist = srcset.split(",")
 
     for src in srclist:
-        url = src.split(' ')[0]
-        assert('s=' in url)
+        url = src.split(" ")[0]
+        assert "s=" in url
 
         actual_signature = get_actual_signature(url)
         expected_signature = make_expected_signature(url)
 
-        assert(expected_signature == actual_signature)
+        assert expected_signature == actual_signature
 
 
 def test_given_height_srcset_generates_pairs():
-    srcset = _default_srcset({'h': 100})
+    srcset = _default_srcset({"h": 100})
     expected_dpr_urls = 5
-    assert(expected_dpr_urls == len(srcset.split(',')))
+    assert expected_dpr_urls == len(srcset.split(","))
 
 
 def test_given_height_respects_parameter():
-    srcset = _default_srcset({'h': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"h": 100})
+    srclist = srcset.split(",")
 
     for src in srclist:
-        assert('h=100' in src)
+        assert "h=100" in src
 
 
 def test_height_based_srcset_has_dpr_values():
-    srcset = _default_srcset({'h': 100})
+    srcset = _default_srcset({"h": 100})
     descriptors = extract_descriptors(srcset)
-    assert(descriptors == ["1x", "2x", "3x", "4x", "5x"])
+    assert descriptors == ["1x", "2x", "3x", "4x", "5x"]
 
 
 def test_given_height_srcset_signs_urls():
-    srcset = _default_srcset({'h': 100})
-    srclist = srcset.split(',')
-    srcs = [src.split(' ')[0] for src in srclist]
+    srcset = _default_srcset({"h": 100})
+    srclist = srcset.split(",")
+    srcs = [src.split(" ")[0] for src in srclist]
 
     for src in srcs:
-        assert(src.index('s='))
+        assert src.index("s=")
 
         actual_signature = get_actual_signature(src)
         expected_signature = make_expected_signature(src)
 
-        assert(expected_signature == actual_signature)
+        assert expected_signature == actual_signature
 
 
 def test_given_width_and_height_is_DPR():
-    srcset = _default_srcset({'w': 100, 'h': 100})
+    srcset = _default_srcset({"w": 100, "h": 100})
     device_pixel_ratio = 1
-    srclist = srcset.split(',')
+    srclist = srcset.split(",")
 
     for src in srclist:
-        ratio = src.split(' ')[1]
-        dpr_str = str(device_pixel_ratio) + 'x'
-        assert(dpr_str == ratio)
+        ratio = src.split(" ")[1]
+        dpr_str = str(device_pixel_ratio) + "x"
+        assert dpr_str == ratio
         device_pixel_ratio += 1
 
 
 def test_given_width_and_height_srcset_has_dpr_params():
-    srcset = _default_srcset({'w': 100, 'h': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"w": 100, "h": 100})
+    srclist = srcset.split(",")
 
     for i in range(len(srclist)):
-        src = srclist[i].split(' ')[0]
-        assert(src.index("dpr=" + str(i+1)))
+        src = srclist[i].split(" ")[0]
+        assert src.index("dpr=" + str(i + 1))
 
 
 def test_given_width_and_height_signs_urls():
-    srcset = _default_srcset({'w': 100, 'h': 100})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"w": 100, "h": 100})
+    srclist = srcset.split(",")
 
     for src in srclist:
-        url = src.split(' ')[0]
-        assert('s=' in url)
+        url = src.split(" ")[0]
+        assert "s=" in url
 
         actual_signature = get_actual_signature(url)
         expected_signature = make_expected_signature(url)
 
-        assert(expected_signature == actual_signature)
+        assert expected_signature == actual_signature
 
 
 def test_given_aspect_ratio_srcset_generates_pairs():
-    srcset = _default_srcset({'ar': '3:2'})
+    srcset = _default_srcset({"ar": "3:2"})
     expected_number_of_pairs = 31
-    assert(expected_number_of_pairs == len(srcset.split(',')))
+    assert expected_number_of_pairs == len(srcset.split(","))
 
 
 def test_given_aspect_ratio_srcset_pairs_within_bounds():
-    srcset = _default_srcset({'ar': '3:2'})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"ar": "3:2"})
+    srclist = srcset.split(",")
 
-    min_parsed = srclist[0].split(' ')[1]
-    max_parsed = srclist[-1].split(' ')[1]
+    min_parsed = srclist[0].split(" ")[1]
+    max_parsed = srclist[-1].split(" ")[1]
     min_size = _parse_width(min_parsed)
     max_size = _parse_width(max_parsed)
 
-    assert(min_size >= IMAGE_MIN_WIDTH)
-    assert(max_size <= IMAGE_MAX_WIDTH)
+    assert min_size >= IMAGE_MIN_WIDTH
+    assert max_size <= IMAGE_MAX_WIDTH
 
 
 # a 17% testing threshold is used to account for rounding
 def test_given_aspect_ratio_srcset_iterates_17_percent():
     increment_allowed = 0.17
-    srcset = _default_srcset({'ar': '3:2'})
-    srcslist = srcset.split(',')
-    widths_list = [src.split(' ')[1] for src in srcslist]
+    srcset = _default_srcset({"ar": "3:2"})
+    srcslist = srcset.split(",")
+    widths_list = [src.split(" ")[1] for src in srcslist]
     # a list of all widths as int
     widths = [_parse_width(width) for width in widths_list]
 
     prev = widths[0]
     for i in range(1, len(widths)):
         width = widths[i]
-        assert((width / prev) < (1 + increment_allowed))
+        assert (width / prev) < (1 + increment_allowed)
         prev = width
 
 
 def test_given_aspect_ratio_srcset_signs_urls():
-    srcset = _default_srcset({'ar': '3:2'})
-    srclist = srcset.split(',')
-    srcs = [src.split(' ')[0] for src in srclist]
+    srcset = _default_srcset({"ar": "3:2"})
+    srclist = srcset.split(",")
+    srcs = [src.split(" ")[0] for src in srclist]
 
     for src in srcs:
-        assert(src.index('s='))
+        assert src.index("s=")
 
         actual_signature = get_actual_signature(src)
         expected_signature = make_expected_signature(src)
 
-        assert(expected_signature == actual_signature)
+        assert expected_signature == actual_signature
 
 
 def test_given_aspect_ratio_and_height_srcset_is_DPR():
-    srcset = _default_srcset({'ar': '3:2', 'h': 500})
+    srcset = _default_srcset({"ar": "3:2", "h": 500})
     device_pixel_ratio = 1
-    srclist = srcset.split(',')
+    srclist = srcset.split(",")
 
     for src in srclist:
-        ratio = src.split(' ')[1]
-        dpr_str = str(device_pixel_ratio) + 'x'
-        assert(dpr_str == ratio)
+        ratio = src.split(" ")[1]
+        dpr_str = str(device_pixel_ratio) + "x"
+        assert dpr_str == ratio
         device_pixel_ratio += 1
 
 
 def test_given_aspect_ratio_and_height_srcset_has_dpr_params():
-    srcset = _default_srcset({'ar': '3:2', 'h': 500})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"ar": "3:2", "h": 500})
+    srclist = srcset.split(",")
 
     for i in range(len(srclist)):
-        src = srclist[i].split(' ')[0]
-        assert(src.index("dpr=" + str(i+1)))
+        src = srclist[i].split(" ")[0]
+        assert src.index("dpr=" + str(i + 1))
 
 
 def test_given_aspect_ratio_and_height_srcset_signs_urls():
-    srcset = _default_srcset({'ar': '3:2', 'h': 500})
-    srclist = srcset.split(',')
+    srcset = _default_srcset({"ar": "3:2", "h": 500})
+    srclist = srcset.split(",")
 
     for src in srclist:
-        url = src.split(' ')[0]
-        assert('s=' in url)
+        url = src.split(" ")[0]
+        assert "s=" in url
 
         actual_signature = get_actual_signature(url)
         expected_signature = make_expected_signature(url)
 
-        assert(expected_signature == actual_signature)
+        assert expected_signature == actual_signature
 
 
 def test_given_fit_params_not_altered():
-    params = {'fit': 'max'}
+    params = {"fit": "max"}
     _default_srcset(params)
-    assert params == {'fit': 'max'}
+    assert params == {"fit": "max"}
 
 
 def test_given_width_params_not_altered():
-    params = {'w': 100}
+    params = {"w": 100}
     _default_srcset(params)
 
-    assert params == {'w': 100}
+    assert params == {"w": 100}
 
 
 class TestSrcsetRaises(unittest.TestCase):

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -25,6 +25,10 @@ def _default_builder_with_signature():
         include_library_param=False,
     )
 
+def _default_builder_with_disable_path_encoding_true():
+    return imgix.UrlBuilder('my-social-network.imgix.net', disable_path_encoding=True,
+                            include_library_param=False)
+
 
 def test_create():
     builder = imgix.UrlBuilder("my-social-network.imgix.net")
@@ -162,6 +166,25 @@ def test_create_url_with_questionable_chars_in_path():
     assert (
         url == "https://my-social-network.imgix.net/" "&$%2B,%3A;=%3F@%23.jpg"
     )
+
+def test_create_url_with_unicode_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url("ساندویچ.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        "ساندویچ.jpg"
+
+def test_create_url_with_spaces_brackets_in_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url(r" <>[]{}|\^%.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        r" <>[]{}|\^%.jpg"
+
+
+def test_create_url_with_questionable_chars_in_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url("&$+,:;=?@#.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        "&$+,:;=?@#.jpg"
 
 
 def test_use_https():

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -12,24 +12,29 @@ def _get_domain(url):
 
 
 def _default_builder():
-    return imgix.UrlBuilder('my-social-network.imgix.net',
-                            include_library_param=False)
+    return imgix.UrlBuilder(
+        "my-social-network.imgix.net", include_library_param=False
+    )
 
 
 def _default_builder_with_signature():
-    return imgix.UrlBuilder('my-social-network.imgix.net', True, "FOO123bar",
-                            include_library_param=False)
+    return imgix.UrlBuilder(
+        "my-social-network.imgix.net",
+        True,
+        "FOO123bar",
+        include_library_param=False,
+    )
 
 
 def test_create():
-    builder = imgix.UrlBuilder('my-social-network.imgix.net')
+    builder = imgix.UrlBuilder("my-social-network.imgix.net")
     assert type(builder) is imgix.UrlBuilder
 
 
 def test_create_accepts_domains_single_str():
-    domain = 'my-social-network-1.imgix.net'
+    domain = "my-social-network-1.imgix.net"
     builder = imgix.UrlBuilder(domain)
-    assert domain == _get_domain(builder.create_url('/users/1.png'))
+    assert domain == _get_domain(builder.create_url("/users/1.png"))
 
 
 def test_create_url_with_path():
@@ -77,26 +82,29 @@ def test_create_url_with_splatted_falsy_parameter():
 def test_create_url_with_path_and_signature():
     builder = _default_builder_with_signature()
     url = builder.create_url("/users/1.png")
-    assert url == \
-        "https://my-social-network.imgix.net/users/1.png" \
+    assert (
+        url == "https://my-social-network.imgix.net/users/1.png"
         "?s=6797c24146142d5b40bde3141fd3600c"
+    )
 
 
 def test_create_url_with_path_and_paremeters_and_signature():
     builder = _default_builder_with_signature()
     url = builder.create_url("/users/1.png", {"w": 400, "h": 300})
-    assert url == \
-        "https://my-social-network.imgix.net/users/1.png" \
+    assert (
+        url == "https://my-social-network.imgix.net/users/1.png"
         "?h=300&w=400&s=1a4e48641614d1109c6a7af51be23d18"
+    )
 
 
 def test_create_url_with_fully_qualified_url():
     builder = _default_builder_with_signature()
     url = builder.create_url("http://avatars.com/john-smith.png")
-    assert url == \
-        "https://my-social-network.imgix.net/"\
-        "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
+    assert (
+        url == "https://my-social-network.imgix.net/"
+        "http%3A%2F%2Favatars.com%2Fjohn-smith.png"
         "?s=493a52f008c91416351f8b33d4883135"
+    )
 
 
 def test_create_url_with_fully_qualified_url_with_tilde():
@@ -108,95 +116,110 @@ def test_create_url_with_fully_qualified_url_with_tilde():
     # "Python 3.7 updates from using RFC 2396 to RFC 3986 to quote URL
     # strings. Now, "~" is included in the set of unreserved characters."
     import sys
+
     if sys.version_info[1] > 6:
-        assert url == \
-            "https://my-social-network.imgix.net/"\
+        assert (
+            url == "https://my-social-network.imgix.net/"
             "http%3A%2F%2Favatars.com%2Fjohn~smith.png"
+        )
     else:
-        assert(True)
+        assert True
 
 
 def test_create_url_with_fully_qualified_url_and_parameters():
     builder = _default_builder_with_signature()
-    url = builder.create_url("http://avatars.com/john-smith.png",
-                             {"w": 400, "h": 300})
-    assert url == \
-        "https://my-social-network.imgix.net/" \
-        "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
+    url = builder.create_url(
+        "http://avatars.com/john-smith.png", {"w": 400, "h": 300}
+    )
+    assert (
+        url == "https://my-social-network.imgix.net/"
+        "http%3A%2F%2Favatars.com%2Fjohn-smith.png"
         "?h=300&w=400&s=a201fe1a3caef4944dcb40f6ce99e746"
+    )
 
 
 def test_create_url_with_unicode_path():
     builder = _default_builder()
     url = builder.create_url("ساندویچ.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
+    assert (
+        url == "https://my-social-network.imgix.net/"
         "%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+    )
 
 
 def test_create_url_with_spaces_brackets_in_path():
     builder = _default_builder()
     url = builder.create_url(r" <>[]{}|\^%.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
+    assert (
+        url == "https://my-social-network.imgix.net/"
         "%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+    )
 
 
 def test_create_url_with_questionable_chars_in_path():
     builder = _default_builder()
     url = builder.create_url("&$+,:;=?@#.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
-        "&$%2B,%3A;=%3F@%23.jpg"
+    assert (
+        url == "https://my-social-network.imgix.net/" "&$%2B,%3A;=%3F@%23.jpg"
+    )
 
 
 def test_use_https():
     # Defaults to https
-    builder = imgix.UrlBuilder('my-social-network.imgix.net')
+    builder = imgix.UrlBuilder("my-social-network.imgix.net")
     url = builder.create_url("/users/1.png")
     assert urlparse(url).scheme == "https"
 
-    builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=False)
+    builder = imgix.UrlBuilder("my-social-network.imgix.net", use_https=False)
     url = builder.create_url("/users/1.png")
     assert urlparse(url).scheme == "http"
 
-    builder = imgix.UrlBuilder('my-social-network.imgix.net', True)
+    builder = imgix.UrlBuilder("my-social-network.imgix.net", True)
     url = builder.create_url("/users/1.png")
     assert urlparse(url).scheme == "https"
 
-    builder = imgix.UrlBuilder('my-social-network.imgix.net', use_https=True)
+    builder = imgix.UrlBuilder("my-social-network.imgix.net", use_https=True)
     url = builder.create_url("/users/1.png")
     assert urlparse(url).scheme == "https"
 
 
 def test_utf_8_characters():
     builder = _default_builder()
-    url = builder.create_url(u'/ǝ')
+    url = builder.create_url("/ǝ")
     assert url == "https://my-social-network.imgix.net/%C7%9D"
 
 
 def test_more_involved_utf_8_characters():
     builder = _default_builder()
-    url = builder.create_url(u'/üsers/1/米国でのパーティーします。.png')
-    assert url == \
-        "https://my-social-network.imgix.net/%C3%BCsers/1/" \
-        "%E7%B1%B3%E5%9B%BD%E3%81%A7%E3%81%AE%E3%83%91%E3%83%BC%E3%83" \
+    url = builder.create_url("/üsers/1/米国でのパーティーします。.png")
+    assert (
+        url == "https://my-social-network.imgix.net/%C3%BCsers/1/"
+        "%E7%B1%B3%E5%9B%BD%E3%81%A7%E3%81%AE%E3%83%91%E3%83%BC%E3%83"
         "%86%E3%82%A3%E3%83%BC%E3%81%97%E3%81%BE%E3%81%99%E3%80%82.png"
+    )
 
 
 def test_param_values_are_escaped():
     builder = _default_builder()
-    url = builder.create_url('demo.png', {"hello world": "interesting"})
+    url = builder.create_url("demo.png", {"hello world": "interesting"})
 
-    assert url == "https://my-social-network.imgix.net/demo.png?" \
+    assert (
+        url == "https://my-social-network.imgix.net/demo.png?"
         "hello%20world=interesting"
+    )
 
 
 def test_param_keys_are_escaped():
     builder = _default_builder()
-    url = builder.create_url('demo.png', {
-        "hello_world": "/foo\"> <script>alert(\"hacked\")</script><"})
+    url = builder.create_url(
+        "demo.png", {"hello_world": '/foo"> <script>alert("hacked")</script><'}
+    )
 
-    assert url == "https://my-social-network.imgix.net/demo.png?" \
-        "hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22" \
+    assert (
+        url == "https://my-social-network.imgix.net/demo.png?"
+        "hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22"
         "hacked%22%29%3C%2Fscript%3E%3C"
+    )
 
 
 def test_base64_param_variants_are_base64_encoded():
@@ -207,70 +230,77 @@ def test_base64_param_variants_are_base64_encoded():
     # "Python 3.7 updates from using RFC 2396 to RFC 3986 to quote URL
     # strings. Now, "~" is included in the set of unreserved characters."
     import sys
-    if sys.version_info[1] > 6:
-        url = builder.create_url('~text', {
-            "txt64": u"I cannøt belîév∑ it wors! 😱"})
 
-        assert url == "https://my-social-network.imgix.net/~text?txt64=" \
+    if sys.version_info[1] > 6:
+        url = builder.create_url(
+            "~text", {"txt64": "I cannøt belîév∑ it wors! 😱"}
+        )
+
+        assert (
+            url == "https://my-social-network.imgix.net/~text?txt64="
             "SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
+        )
     else:
-        assert(True)
+        assert True
 
 
 def test_signing_url_with_ixlib():
-    builder = imgix.UrlBuilder('my-social-network.imgix.net')
+    builder = imgix.UrlBuilder("my-social-network.imgix.net")
     url = builder.create_url("/users/1.png")
     assert url == (
-        "https://my-social-network.imgix.net/users/1.png?ixlib=python-" +
-        imgix._version.__version__)
+        "https://my-social-network.imgix.net/users/1.png?ixlib=python-"
+        + imgix._version.__version__
+    )
 
 
 def test_invalid_domain_append_slash():
-    url_append_slash = 'assets.imgix.net/products'
+    url_append_slash = "assets.imgix.net/products"
 
     # Should fail if the expected error isn't raised
     try:
         imgix.UrlBuilder(url_append_slash)
     except ValueError:
-        assert(True)
+        assert True
     else:
-        assert(False)
+        assert False
 
 
 def test_invalid_domain_prepend_scheme():
-    url_prepend_protocol = 'https://assets.imgix.net'
+    url_prepend_protocol = "https://assets.imgix.net"
 
     # Should fail if the expected error isn't raised
     try:
         imgix.UrlBuilder(url_prepend_protocol)
     except ValueError:
-        assert(True)
+        assert True
     else:
-        assert(False)
+        assert False
 
 
 def test_invalid_domain_append_dash():
-    url_append_dash = 'assets.imgix.net-products'
+    url_append_dash = "assets.imgix.net-products"
 
     # Should fail if the expected error isn't raised
     try:
         imgix.UrlBuilder(url_append_dash)
     except ValueError:
-        assert(True)
+        assert True
     else:
-        assert(False)
+        assert False
 
 
 def test_include_library_param_true():
-    url = ("https://assets.imgix.net/image.jpg?ixlib=python-" +
-           imgix._version.__version__)
+    url = (
+        "https://assets.imgix.net/image.jpg?ixlib=python-"
+        + imgix._version.__version__
+    )
     ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=True)
 
     assert url == ub.create_url("image.jpg")
 
 
 def test_include_library_param_false():
-    url = 'https://assets.imgix.net/image.jpg'
+    url = "https://assets.imgix.net/image.jpg"
     ub = imgix.UrlBuilder("assets.imgix.net", include_library_param=False)
 
     assert url == ub.create_url("image.jpg")
@@ -292,7 +322,7 @@ def test_target_widths_100_7401():
 
 def test_target_widths_328_4087():
     idx_of_328, idx_of_4087 = 8, -5
-    expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328: idx_of_4087]
+    expected = constants.SRCSET_TARGET_WIDTHS[idx_of_328:idx_of_4087]
     actual = urlbuilder.target_widths(start=328, stop=4087)
     assert len(actual) == len(expected)
     assert actual[0] == expected[0]

--- a/tests/test_url_helper.py
+++ b/tests/test_url_helper.py
@@ -6,75 +6,104 @@ from imgix.urlhelper import UrlHelper
 
 
 def test_create():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png')
+    helper = UrlHelper("my-social-network.imgix.net", "/users/1.png")
     assert type(helper) is UrlHelper
 
 
 def test_create_with_url_parameters():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       include_library_param=False,
-                       params={"w": 400, "h": 300})
-    assert str(helper) == "https://my-social-network.imgix.net/users/1.png?" \
-                          "h=300&w=400"
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        include_library_param=False,
+        params={"w": 400, "h": 300},
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/users/1.png?"
+        "h=300&w=400"
+    )
 
 
 def test_create_with_splatted_falsy_parameter():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       include_library_param=False,
-                       params={"or": 0})
-    assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?or=0"
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        include_library_param=False,
+        params={"or": 0},
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net"
+        "/users/1.png?or=0"
+    )
 
 
 def test_create_with_signature():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       sign_key="FOO123bar",
-                       include_library_param=False)
-    assert str(helper) == \
-        "https://my-social-network.imgix.net/users/1.png" \
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        sign_key="FOO123bar",
+        include_library_param=False,
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/users/1.png"
         "?s=6797c24146142d5b40bde3141fd3600c"
+    )
 
 
 def test_create_with_paremeters_and_signature():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       sign_key="FOO123bar",
-                       include_library_param=False,
-                       params={"w": 400, "h": 300})
-    assert str(helper) == \
-        "https://my-social-network.imgix.net/users/1.png" \
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        sign_key="FOO123bar",
+        include_library_param=False,
+        params={"w": 400, "h": 300},
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/users/1.png"
         "?h=300&w=400&s=1a4e48641614d1109c6a7af51be23d18"
+    )
 
 
 def test_create_with_fully_qualified_url():
-    helper = UrlHelper("my-social-network.imgix.net",
-                       "http://avatars.com/john-smith.png",
-                       sign_key="FOO123bar",
-                       include_library_param=False)
-    assert str(helper) == \
-        "https://my-social-network.imgix.net/"\
-        "http%3A%2F%2Favatars.com%2Fjohn-smith.png" \
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "http://avatars.com/john-smith.png",
+        sign_key="FOO123bar",
+        include_library_param=False,
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/"
+        "http%3A%2F%2Favatars.com%2Fjohn-smith.png"
         "?s=493a52f008c91416351f8b33d4883135"
+    )
 
 
 def test_create_with_fully_qualified_url_with_special_chars():
-    helper = UrlHelper("my-social-network.imgix.net",
-                       u"http://avatars.com/でのパ.png",
-                       sign_key="FOO123bar",
-                       include_library_param=False)
-    assert str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F" \
-                          "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png" \
-                          "?s=8e04a5dd9a659a6a540d7c817d3df1d3"
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "http://avatars.com/でのパ.png",
+        sign_key="FOO123bar",
+        include_library_param=False,
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F"
+        "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png"
+        "?s=8e04a5dd9a659a6a540d7c817d3df1d3"
+    )
 
 
 def test_create_with_mixed_strings_and_unicodes():
-    helper = UrlHelper("my-social-network.imgix.net",
-                       u"http://avatars.com/でのパ.png",
-                       sign_key="FOO123bar",
-                       params={"w": '400', u"h": u'300'},
-                       include_library_param=False)
-    assert str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F" \
-                          "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png" \
-                          "?h=300&w=400&s=8b97a8fffdfa639af4bae846a9661c50"
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "http://avatars.com/でのパ.png",
+        sign_key="FOO123bar",
+        params={"w": "400", "h": "300"},
+        include_library_param=False,
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/http%3A%2F%2F"
+        "avatars.com%2F%E3%81%A7%E3%81%AE%E3%83%91.png"
+        "?h=300&w=400&s=8b97a8fffdfa639af4bae846a9661c50"
+    )
 
 
 def test_use_https():
@@ -82,147 +111,204 @@ def test_use_https():
     helper = UrlHelper("my-social-network.imgix.net", "/users/1.png")
     assert urlparse(str(helper)).scheme == "https"
 
-    helper = UrlHelper('my-social-network.imgix.net', "/users/1.png",
-                       scheme="http")
+    helper = UrlHelper(
+        "my-social-network.imgix.net", "/users/1.png", scheme="http"
+    )
     assert urlparse(str(helper)).scheme == "http"
 
 
 def test_utf_8_characters():
-    helper = UrlHelper('my-social-network.imgix.net', u'/ǝ',
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net", "/ǝ", include_library_param=False
+    )
     assert str(helper) == "https://my-social-network.imgix.net/%C7%9D"
 
 
 def test_more_involved_utf_8_characters():
-    helper = UrlHelper('my-social-network.imgix.net',
-                       u'/üsers/1/でのパ.png',
-                       include_library_param=False)
-    assert str(helper) == 'https://my-social-network.imgix.net/' \
-                          '%C3%BCsers/1/%E3%81%A7%E3%81%AE%E3%83%91.png'
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/üsers/1/でのパ.png",
+        include_library_param=False,
+    )
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/"
+        "%C3%BCsers/1/%E3%81%A7%E3%81%AE%E3%83%91.png"
+    )
 
 
 def test_param_values_are_escaped():
-    helper = UrlHelper('my-social-network.imgix.net', 'demo.png',
-                       params={"hello world": "interesting"},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "demo.png",
+        params={"hello world": "interesting"},
+        include_library_param=False,
+    )
 
-    assert str(helper) == "https://my-social-network.imgix.net/demo.png?" \
-                          "hello%20world=interesting"
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/demo.png?"
+        "hello%20world=interesting"
+    )
 
 
 def test_param_keys_are_escaped():
-    params = {"hello_world": "/foo\"> <script>alert(\"hacked\")</script><"}
-    helper = UrlHelper('my-social-network.imgix.net', 'demo.png',
-                       params=params,
-                       include_library_param=False)
+    params = {"hello_world": '/foo"> <script>alert("hacked")</script><'}
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "demo.png",
+        params=params,
+        include_library_param=False,
+    )
 
-    assert str(helper) == "https://my-social-network.imgix.net/demo.png?" \
-        "hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22" \
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/demo.png?"
+        "hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22"
         "hacked%22%29%3C%2Fscript%3E%3C"
+    )
 
 
 def test_base64_param_variants_are_base64_encoded():
-    params = {"txt64": u"I cannøt belîév∑ it wors! 😱"}
+    params = {"txt64": "I cannøt belîév∑ it wors! 😱"}
 
     # Temporary Fix
     # Reason:
     # "Python 3.7 updates from using RFC 2396 to RFC 3986 to quote URL
     # strings. Now, "~" is included in the set of unreserved characters."
     import sys
-    if sys.version_info[1] > 6:
-        helper = UrlHelper('my-social-network.imgix.net', '~text',
-                           params=params,
-                           include_library_param=False)
 
-        assert str(helper) == "https://my-social-network.imgix.net/" \
+    if sys.version_info[1] > 6:
+        helper = UrlHelper(
+            "my-social-network.imgix.net",
+            "~text",
+            params=params,
+            include_library_param=False,
+        )
+
+        assert (
+            str(helper) == "https://my-social-network.imgix.net/"
             "~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
+        )
     else:
-        assert(True)
+        assert True
 
 
 def test_signing_url_with_ixlib():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png')
+    helper = UrlHelper("my-social-network.imgix.net", "/users/1.png")
     assert str(helper) == (
-        "https://my-social-network.imgix.net/users/1.png?ixlib=python-" +
-        imgix._version.__version__)
+        "https://my-social-network.imgix.net/users/1.png?ixlib=python-"
+        + imgix._version.__version__
+    )
 
 
 def test_set_parameter():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        include_library_param=False,
+    )
 
-    helper.set_parameter('w', 400)
-    assert str(helper) == "https://my-social-network.imgix.net/" \
-                          "users/1.png?w=400"
+    helper.set_parameter("w", 400)
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/"
+        "users/1.png?w=400"
+    )
 
-    helper.set_parameter('h', 300)
-    assert str(helper) == "https://my-social-network.imgix.net/" \
-                          "users/1.png?h=300&w=400"
+    helper.set_parameter("h", 300)
+    assert (
+        str(helper) == "https://my-social-network.imgix.net/"
+        "users/1.png?h=300&w=400"
+    )
 
 
 def test_set_parameter_with_init_params():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       params={"or": 0},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        params={"or": 0},
+        include_library_param=False,
+    )
 
-    helper.set_parameter('w', 400)
-    helper.set_parameter('h', 300)
-    assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300&or=0&w=400"
+    helper.set_parameter("w", 400)
+    helper.set_parameter("h", 300)
+    assert (
+        str(helper) == "https://my-social-network.imgix.net"
+        "/users/1.png?h=300&or=0&w=400"
+    )
 
 
 def test_set_parameter_base64_encoded():
-    helper = UrlHelper('my-social-network.imgix.net', '~text',
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net", "~text", include_library_param=False
+    )
 
     # Temporary Fix
     # Reason:
     # "Python 3.7 updates from using RFC 2396 to RFC 3986 to quote URL
     # strings. Now, "~" is included in the set of unreserved characters."
     import sys
+
     if sys.version_info[1] > 6:
-        helper.set_parameter("txt64", u"I cannøt belîév∑ it wors! 😱")
-        assert str(helper) == "https://my-social-network.imgix.net/" \
+        helper.set_parameter("txt64", "I cannøt belîév∑ it wors! 😱")
+        assert (
+            str(helper) == "https://my-social-network.imgix.net/"
             "~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE"
+        )
     else:
-        assert(True)
+        assert True
 
 
 def test_set_parameter_with_none_value():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       params={'h': 300, 'w': 400},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        params={"h": 300, "w": 400},
+        include_library_param=False,
+    )
 
     helper.set_parameter("w", None)
-    assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300&w=None"
+    assert (
+        str(helper) == "https://my-social-network.imgix.net"
+        "/users/1.png?h=300&w=None"
+    )
 
 
 def test_set_parameter_with_false_value():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       params={'h': 300, 'w': 400},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        params={"h": 300, "w": 400},
+        include_library_param=False,
+    )
 
     helper.set_parameter("w", False)
-    assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300&w=False"
+    assert (
+        str(helper) == "https://my-social-network.imgix.net"
+        "/users/1.png?h=300&w=False"
+    )
 
 
 def test_delete_parameter():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       params={'h': 300, 'w': 400},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        params={"h": 300, "w": 400},
+        include_library_param=False,
+    )
 
-    helper.delete_parameter('w')
-    assert str(helper) == "https://my-social-network.imgix.net" \
-                          "/users/1.png?h=300"
+    helper.delete_parameter("w")
+    assert (
+        str(helper) == "https://my-social-network.imgix.net"
+        "/users/1.png?h=300"
+    )
 
 
 def test_delete_all_parameters():
-    helper = UrlHelper('my-social-network.imgix.net', '/users/1.png',
-                       params={'h': 300, 'w': 400},
-                       include_library_param=False)
+    helper = UrlHelper(
+        "my-social-network.imgix.net",
+        "/users/1.png",
+        params={"h": 300, "w": 400},
+        include_library_param=False,
+    )
 
-    helper.delete_parameter('w')
-    helper.delete_parameter('h')
+    helper.delete_parameter("w")
+    helper.delete_parameter("h")
     assert str(helper) == "https://my-social-network.imgix.net/users/1.png"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,10 +1,19 @@
 import unittest
 
-from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, \
-    IMAGE_ZERO_WIDTH, SRCSET_MIN_WIDTH_TOLERANCE
+from imgix.constants import (
+    IMAGE_MIN_WIDTH,
+    IMAGE_MAX_WIDTH,
+    IMAGE_ZERO_WIDTH,
+    SRCSET_MIN_WIDTH_TOLERANCE,
+)
 
-from imgix.validators import validate_min_width, validate_max_width, \
-    validate_range, validate_min_max_tol, validate_widths
+from imgix.validators import (
+    validate_min_width,
+    validate_max_width,
+    validate_range,
+    validate_min_max_tol,
+    validate_widths,
+)
 
 from imgix.errors import WidthRangeError, WidthToleranceError
 
@@ -55,17 +64,15 @@ class TestValidators(unittest.TestCase):
             # `IMAGE_ZERO_WIDTH` is being used to
             # simulate a `tol` < ONE_PERCENT.
             validate_min_max_tol(
-                IMAGE_MIN_WIDTH,
-                IMAGE_MAX_WIDTH,
-                IMAGE_ZERO_WIDTH)
+                IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, IMAGE_ZERO_WIDTH
+            )
 
     def test_validate_min_max_tol(self):
         # Due to the assertive nature of this validator
         # if this test does not raise, it passes.
         validate_min_max_tol(
-            IMAGE_MIN_WIDTH,
-            IMAGE_MAX_WIDTH,
-            SRCSET_MIN_WIDTH_TOLERANCE)
+            IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH, SRCSET_MIN_WIDTH_TOLERANCE
+        )
 
     def test_start_equals_stop(self):
         # Due to the assertive nature of this validator


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
Before this PR, this library would encode all paths passed to either `create_url()` or `create_srcset()`. This was a great default in a lot of scenarios, but this proved to be irritating when integrating with some data sources that provided already encoded URL paths.

<!-- After this PR... -->
After this PR, the library would allow users to optionally pass a boolean argument `disable_path_encoding` while creating an object of the `UrlBuilder` class. 

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->
## Steps to test
* Testing the `create_url()` method

  ```python
  >>> from imgix import UrlBuilder
  >>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
  >>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
  'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
  ```
  Normally this would output a source URL like `https://sdk-test.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25.jpg?h=100&2=100`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100`.

* Testing the `create_scrset()` method
  ```python
  >>> from imgix import UrlBuilder
  >>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
  >>> ub.create_srcset("image<>[]{} 123.png", widths=[100])
  'https://sdk-test.imgix.net/image<>[]{} 123.png?&w=100 100w'
  ```
  Normally this would output a source URL like `https://sdk-test.imgix.net/image%3C%3E%5B%5D%7B%7D%20123.png?&w=100 100w`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net//image<>[]{} 123.png?&w=100 100w`.

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [ ] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [ ] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [ ] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
