### PR TITLE
feat: add functionality to optionally disable path encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [Signed URLs](#signed-urls)
+- [Disabled Path Encoding](#disabled-path-encoding)
 - [Srcset Generation](#srcset-generation)
     * [Fixed-Width Images](#fixed-width-images)
         + [Variable Quality](#variable-quality)
@@ -68,6 +69,19 @@ To produce a signed URL, you must enable secure URLs on your source and then pro
 'https://demo.imgix.net/bridge.png?h=100&w=100&s=bb8f3a2ab832e35997456823272103a4'
 
 ```
+
+## Disabled Path Encoding
+
+Path encoding is enabled by default. It can be toggled off by setting `disable_path_encoding` to `True`:
+
+```python
+>>> from imgix import UrlBuilder
+>>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
+>>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
+'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
+```
+
+Normally this would output a source URL like `https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25.jpg?h=100&2=100`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100`.
 
 ## Srcset Generation
 

--- a/README.md
+++ b/README.md
@@ -72,16 +72,24 @@ To produce a signed URL, you must enable secure URLs on your source and then pro
 
 ## Disabled Path Encoding
 
-Path encoding is enabled by default. It can be toggled off by setting `disable_path_encoding` to `True`:
+Path encoding is enabled by default. It can be toggled off by setting `disable_path_encoding` to `True` in the optional `options` paramater in `create_url()` and `create_srcset()` functions:
 
 ```python
 >>> from imgix import UrlBuilder
->>> ub = UrlBuilder("sdk-test.imgix.net", disable_path_encoding=True)
->>> ub.create_url(" <>[]{}|^%.jpg", {'w': 100, 'h': 100})  
+>>> ub = UrlBuilder("sdk-test.imgix.net")
+>>> ub.create_url(" <>[]{}|^%.jpg", params={'w': 100, 'h': 100}, options={'disable_path_encoding': True})
 'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
 ```
 
 Normally this would output a source URL like `https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25.jpg?h=100&2=100`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100`.
+
+```python
+>>> from imgix import UrlBuilder
+>>> ub = UrlBuilder("sdk-test.imgix.net")
+>>> ub.create_srcset("image<>[]{} 123.png", widths=[100], options={'disable_path_encoding': True})
+'https://sdk-test.imgix.net/image<>[]{} 123.png?w=100 100w'
+```
+Normally this would output a source URL like `https://sdk-test.imgix.net/image%3C%3E%5B%5D%7B%7D%20123.png?&w=100 100w`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net//image<>[]{} 123.png?w=100 100w`.
 
 ## Srcset Generation
 

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -37,6 +37,8 @@ class UrlBuilder(object):
     include_library_param : bool
         If `True`, each created URL is suffixed with 'ixlib' parameter
         indicating the library used for generating the URLs. (default `True`)
+    disable_path_encoding : bool
+        If `True`, the path component of the URL will not be encoded. (default `False`)
 
     Methods
     -------
@@ -58,7 +60,8 @@ class UrlBuilder(object):
             domain,
             use_https=True,
             sign_key=None,
-            include_library_param=True):
+            include_library_param=True,
+            disable_path_encoding=False):
 
         self.validate_domain(domain)
 
@@ -66,6 +69,7 @@ class UrlBuilder(object):
         self._sign_key = sign_key
         self._use_https = use_https
         self._include_library_param = include_library_param
+        self._disable_path_encoding = disable_path_encoding
 
     def validate_domain(self, domain):
         """
@@ -133,7 +137,9 @@ class UrlBuilder(object):
 
         # Encode the path without a leading forward slash,
         # then add it back before returning.
-        if _path.startswith("http"):
+        if self._disable_path_encoding:
+            return "/" + _path
+        elif _path.startswith("http"):
             return "/" + self._encode_proxy_path(_path)
         else:
             return "/" + self._encode_file_path(_path)

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -38,7 +38,8 @@ class UrlBuilder(object):
         If `True`, each created URL is suffixed with 'ixlib' parameter
         indicating the library used for generating the URLs. (default `True`)
     disable_path_encoding : bool
-        If `True`, the path component of the URL will not be encoded. (default `False`)
+        If `True`, the path component of the URL
+        will not be encoded. (default `False`)
 
     Methods
     -------
@@ -56,12 +57,13 @@ class UrlBuilder(object):
     """
 
     def __init__(
-            self,
-            domain,
-            use_https=True,
-            sign_key=None,
-            include_library_param=True,
-            disable_path_encoding=False):
+        self,
+        domain,
+        use_https=True,
+        sign_key=None,
+        include_library_param=True,
+        disable_path_encoding=False,
+    ):
 
         self.validate_domain(domain)
 
@@ -86,9 +88,10 @@ class UrlBuilder(object):
         """
 
         err_str = str(
-            'Domain must be passed in as fully-qualified domain names and ' +
-            'should not include a protocol or any path element, i.e. ' +
-            '"example.imgix.net".')
+            "Domain must be passed in as fully-qualified domain names and "
+            + "should not include a protocol or any path element, i.e. "
+            + '"example.imgix.net".'
+        )
 
         if re.match(DOMAIN_PATTERN, domain) is None:
             raise ValueError(err_str)
@@ -120,10 +123,7 @@ class UrlBuilder(object):
 
         scheme = "https" if self._use_https else "http"
 
-        return scheme + "://" \
-            + self._domain \
-            + sanitized_path \
-            + query_string
+        return scheme + "://" + self._domain + sanitized_path + query_string
 
     def _sanitize_path(self, path):
         if not path:
@@ -165,21 +165,24 @@ class UrlBuilder(object):
                 # First we call encode on v to get a bytes-like object,
                 # then after replacing any padding characters that may
                 # be present, we call decode to get back a string object.
-                _params[k] = urlsafe_b64encode(
-                    v.encode('utf-8')).replace(b"=", b'').decode("utf-8")
+                _params[k] = (
+                    urlsafe_b64encode(v.encode("utf-8"))
+                    .replace(b"=", b"")
+                    .decode("utf-8")
+                )
             else:
                 # quote_plus will encode SPACE (' ') as PLUS (+). If a
                 # PLUS (+) is present, e.g. "Futura+Condensed Medium",
                 # it will be encoded as "Futura%2BCondensed+Medium".
                 _params[k] = quote_plus(v).replace("+", "%20")
 
-        query_string = [f'{k}={_params[k]}' for k in sorted(_params.keys())]
+        query_string = [f"{k}={_params[k]}" for k in sorted(_params.keys())]
         delimeter = "?" if query_string else ""
         return delimeter + "&".join(query_string)
 
     def _sign_url(self, prefixed_path, query_string):
         signature_base = self._sign_key + prefixed_path + query_string
-        signature = hashlib.md5(signature_base.encode('utf-8')).hexdigest()
+        signature = hashlib.md5(signature_base.encode("utf-8")).hexdigest()
         delimeter = "&s=" if query_string else "?s="
         return query_string + delimeter + signature
 
@@ -234,16 +237,16 @@ class UrlBuilder(object):
         str
             Srcset attribute string.
         """
-        widths_list = kwargs.get('widths', None)
+        widths_list = kwargs.get("widths", None)
         if widths_list:
             validate_widths(widths_list)
             return self._build_srcset_pairs(path, params, targets=widths_list)
 
         # Attempt to assign `start`, `stop`, and `tol` from `kwargs`.
         # If the key does not exist, assign `None`.
-        start = kwargs.get('start', None)
-        stop = kwargs.get('stop', None)
-        tol = kwargs.get('tol', None)
+        start = kwargs.get("start", None)
+        stop = kwargs.get("stop", None)
+        tol = kwargs.get("tol", None)
 
         # Attempt to generate the specified target widths.
         # Assign defaults where appropriate, then validate
@@ -258,35 +261,38 @@ class UrlBuilder(object):
 
         validate_min_max_tol(start, stop, tol)
 
-        targets = \
-            target_widths(start=start, stop=stop, tol=tol)
+        targets = target_widths(start=start, stop=stop, tol=tol)
 
-        if 'w' in params or 'h' in params:
-            disable_variable_quality = \
-                kwargs.get('disable_variable_quality', False)
+        if "w" in params or "h" in params:
+            disable_variable_quality = kwargs.get(
+                "disable_variable_quality", False
+            )
             return self._build_srcset_DPR(
-                path,
-                params,
-                disable_variable_quality=disable_variable_quality)
+                path, params, disable_variable_quality=disable_variable_quality
+            )
         else:
             return self._build_srcset_pairs(path, params, targets)
 
-    def _build_srcset_pairs(
-            self, path, params, targets=TARGET_WIDTHS):
+    def _build_srcset_pairs(self, path, params, targets=TARGET_WIDTHS):
         # prevents mutating the params dict
         srcset_params = dict(params)
         srcset_entries = []
 
         for w in targets:
-            srcset_params['w'] = w
-            srcset_entries.append(self.create_url(path, srcset_params) +
-                                  " " + str(w) + "w")
+            srcset_params["w"] = w
+            srcset_entries.append(
+                self.create_url(path, srcset_params) + " " + str(w) + "w"
+            )
 
         return ",\n".join(srcset_entries)
 
     def _build_srcset_DPR(
-            self, path, params, targets=TARGET_RATIOS,
-            disable_variable_quality=False):
+        self,
+        path,
+        params,
+        targets=TARGET_RATIOS,
+        disable_variable_quality=False,
+    ):
         # If variable quality output is _not disabled_, then output
         # quality values, 'q', will vary in accordance with the
         # default `DPR_QUALITIES` [1x => q=75, ... 5x => 20].
@@ -305,14 +311,15 @@ class UrlBuilder(object):
         srcset_entries = []
 
         for dpr in targets:
-            srcset_params['dpr'] = dpr
+            srcset_params["dpr"] = dpr
 
             if not disable_variable_quality:
-                quality = params.get('q', DPR_QUALITIES[dpr])
-                srcset_params['q'] = quality
+                quality = params.get("q", DPR_QUALITIES[dpr])
+                srcset_params["q"] = quality
 
-            srcset_entries.append(self.create_url(path, srcset_params) +
-                                  " " + str(dpr) + "x")
+            srcset_entries.append(
+                self.create_url(path, srcset_params) + " " + str(dpr) + "x"
+            )
 
         return ",\n".join(srcset_entries)
 

--- a/imgix/urlbuilder.py
+++ b/imgix/urlbuilder.py
@@ -135,19 +135,12 @@ class UrlBuilder(object):
 
         # Encode the path without a leading forward slash,
         # then add it back before returning.
-        # disable_path_encoding = not options["encode"]
         if options["disable_path_encoding"]:
             return "/" + _path
         elif _path.startswith("http"):
             return "/" + self._encode_proxy_path(_path)
         else:
             return "/" + self._encode_file_path(_path)
-        # if options["encode"] != False:
-        #     if _path.startswith("http"):
-        #         return "/" + self._encode_proxy_path(_path)
-        #     else:
-        #         return "/" + self._encode_file_path(_path)
-        # return "/" + _path
 
     def _encode_file_path(self, path):
         return quote(path, safe="/&$;=@,")

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -14,6 +14,7 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH
 DOMAIN = "testing.imgix.net"
 TOKEN = "MYT0KEN"
 JPG_PATH = "image.jpg"
+JPG_PATH_WITH_SPACE = 'image 123.jpg'
 
 
 def extract_descriptors(srcset=""):
@@ -130,6 +131,22 @@ def test_create_srcset_100_to_108():
     )
 
     assert expected == actual
+
+
+def test_create_srcset_with_widths_and_disable_path_encoding_true():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, widths=[100])
+    expected = "https://testing.imgix.net/image 123.jpg?w=100 100w"
+
+    assert(expected == actual)
+
+
+def test_create_srcset_start_equals_stop_with_disable_path_encoding_true():
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, start=713, stop=713)
+    expected = "https://testing.imgix.net/image 123.jpg?w=713 713w"
+
+    assert(expected == actual)
 
 
 def test_given_width_srcset_is_DPR():

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -14,7 +14,7 @@ from imgix.constants import IMAGE_MIN_WIDTH, IMAGE_MAX_WIDTH
 DOMAIN = "testing.imgix.net"
 TOKEN = "MYT0KEN"
 JPG_PATH = "image.jpg"
-JPG_PATH_WITH_SPACE = 'image 123.jpg'
+JPG_PATH_WITH_SPACE = "image 123.jpg"
 
 
 def extract_descriptors(srcset=""):
@@ -134,19 +134,23 @@ def test_create_srcset_100_to_108():
 
 
 def test_create_srcset_with_widths_and_disable_path_encoding_true():
-    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    ub = imgix.UrlBuilder(
+        DOMAIN, include_library_param=False, disable_path_encoding=True
+    )
     actual = ub.create_srcset(JPG_PATH_WITH_SPACE, widths=[100])
     expected = "https://testing.imgix.net/image 123.jpg?w=100 100w"
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_create_srcset_start_equals_stop_with_disable_path_encoding_true():
-    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False, disable_path_encoding=True)
+    ub = imgix.UrlBuilder(
+        DOMAIN, include_library_param=False, disable_path_encoding=True
+    )
     actual = ub.create_srcset(JPG_PATH_WITH_SPACE, start=713, stop=713)
     expected = "https://testing.imgix.net/image 123.jpg?w=713 713w"
 
-    assert(expected == actual)
+    assert expected == actual
 
 
 def test_given_width_srcset_is_DPR():

--- a/tests/test_srcset.py
+++ b/tests/test_srcset.py
@@ -134,20 +134,25 @@ def test_create_srcset_100_to_108():
 
 
 def test_create_srcset_with_widths_and_disable_path_encoding_true():
-    ub = imgix.UrlBuilder(
-        DOMAIN, include_library_param=False, disable_path_encoding=True
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(
+        JPG_PATH_WITH_SPACE,
+        widths=[100],
+        options={"disable_path_encoding": True},
     )
-    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, widths=[100])
     expected = "https://testing.imgix.net/image 123.jpg?w=100 100w"
 
     assert expected == actual
 
 
 def test_create_srcset_start_equals_stop_with_disable_path_encoding_true():
-    ub = imgix.UrlBuilder(
-        DOMAIN, include_library_param=False, disable_path_encoding=True
+    ub = imgix.UrlBuilder(DOMAIN, include_library_param=False)
+    actual = ub.create_srcset(
+        JPG_PATH_WITH_SPACE,
+        start=713,
+        stop=713,
+        options={"disable_path_encoding": True},
     )
-    actual = ub.create_srcset(JPG_PATH_WITH_SPACE, start=713, stop=713)
     expected = "https://testing.imgix.net/image 123.jpg?w=713 713w"
 
     assert expected == actual

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -26,6 +26,11 @@ def _default_builder_with_signature():
     )
 
 
+def _default_builder_with_disable_path_encoding_true():
+    return imgix.UrlBuilder('my-social-network.imgix.net', disable_path_encoding=True,
+                            include_library_param=False)
+
+
 def test_create():
     builder = imgix.UrlBuilder("my-social-network.imgix.net")
     assert type(builder) is imgix.UrlBuilder
@@ -162,6 +167,26 @@ def test_create_url_with_questionable_chars_in_path():
     assert (
         url == "https://my-social-network.imgix.net/" "&$%2B,%3A;=%3F@%23.jpg"
     )
+
+
+def test_create_url_with_unicode_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url("ساندویچ.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        "ساندویچ.jpg"
+
+def test_create_url_with_spaces_brackets_in_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url(r" <>[]{}|\^%.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        r" <>[]{}|\^%.jpg"
+
+
+def test_create_url_with_questionable_chars_in_path_and_disable_path_encoding_true():
+    builder = _default_builder_with_disable_path_encoding_true()
+    url = builder.create_url("&$+,:;=?@#.jpg")
+    assert url == "https://my-social-network.imgix.net/" \
+        "&$+,:;=?@#.jpg"
 
 
 def test_use_https():

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -26,14 +26,6 @@ def _default_builder_with_signature():
     )
 
 
-def _default_builder_with_disable_path_encoding_true():
-    return imgix.UrlBuilder(
-        "my-social-network.imgix.net",
-        disable_path_encoding=True,
-        include_library_param=False,
-    )
-
-
 def test_create():
     builder = imgix.UrlBuilder("my-social-network.imgix.net")
     assert type(builder) is imgix.UrlBuilder
@@ -173,20 +165,26 @@ def test_create_url_with_questionable_chars_in_path():
 
 
 def test_create_url_with_unicode_path_and_disabled_path_encoding():
-    builder = _default_builder_with_disable_path_encoding_true()
-    url = builder.create_url("ساندویچ.jpg")
+    builder = _default_builder()
+    url = builder.create_url(
+        "ساندویچ.jpg", options={"disable_path_encoding": True}
+    )
     assert url == "https://my-social-network.imgix.net/" "ساندویچ.jpg"
 
 
 def test_create_url_with_spaces_brackets_in_path_and_disabled_path_encoding():
-    builder = _default_builder_with_disable_path_encoding_true()
-    url = builder.create_url(r" <>[]{}|\^%.jpg")
+    builder = _default_builder()
+    url = builder.create_url(
+        r" <>[]{}|\^%.jpg", options={"disable_path_encoding": True}
+    )
     assert url == "https://my-social-network.imgix.net/" r" <>[]{}|\^%.jpg"
 
 
 def test_create_url_with_special_chars_in_path_and_disabled_path_encoding():
-    builder = _default_builder_with_disable_path_encoding_true()
-    url = builder.create_url("&$+,:;=?@#.jpg")
+    builder = _default_builder()
+    url = builder.create_url(
+        "&$+,:;=?@#.jpg", options={"disable_path_encoding": True}
+    )
     assert url == "https://my-social-network.imgix.net/" "&$+,:;=?@#.jpg"
 
 

--- a/tests/test_url_builder.py
+++ b/tests/test_url_builder.py
@@ -27,8 +27,11 @@ def _default_builder_with_signature():
 
 
 def _default_builder_with_disable_path_encoding_true():
-    return imgix.UrlBuilder('my-social-network.imgix.net', disable_path_encoding=True,
-                            include_library_param=False)
+    return imgix.UrlBuilder(
+        "my-social-network.imgix.net",
+        disable_path_encoding=True,
+        include_library_param=False,
+    )
 
 
 def test_create():
@@ -169,24 +172,22 @@ def test_create_url_with_questionable_chars_in_path():
     )
 
 
-def test_create_url_with_unicode_path_and_disable_path_encoding_true():
+def test_create_url_with_unicode_path_and_disabled_path_encoding():
     builder = _default_builder_with_disable_path_encoding_true()
     url = builder.create_url("ساندویچ.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
-        "ساندویچ.jpg"
+    assert url == "https://my-social-network.imgix.net/" "ساندویچ.jpg"
 
-def test_create_url_with_spaces_brackets_in_path_and_disable_path_encoding_true():
+
+def test_create_url_with_spaces_brackets_in_path_and_disabled_path_encoding():
     builder = _default_builder_with_disable_path_encoding_true()
     url = builder.create_url(r" <>[]{}|\^%.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
-        r" <>[]{}|\^%.jpg"
+    assert url == "https://my-social-network.imgix.net/" r" <>[]{}|\^%.jpg"
 
 
-def test_create_url_with_questionable_chars_in_path_and_disable_path_encoding_true():
+def test_create_url_with_special_chars_in_path_and_disabled_path_encoding():
     builder = _default_builder_with_disable_path_encoding_true()
     url = builder.create_url("&$+,:;=?@#.jpg")
-    assert url == "https://my-social-network.imgix.net/" \
-        "&$+,:;=?@#.jpg"
+    assert url == "https://my-social-network.imgix.net/" "&$+,:;=?@#.jpg"
 
 
 def test_use_https():


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
Before this PR, this library would encode all paths passed to either `create_url()` or `create_srcset()`. This was a great default in a lot of scenarios, but this proved to be irritating when integrating with some data sources that provided already encoded URL paths.

<!-- After this PR... -->
After this PR, the library would allow users to optionally pass a options parameter containing `disable_path_encoding` having boolean value.

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->
## Steps to test
* Testing the `create_url()` method

  ```python
  >>> from imgix import UrlBuilder
  >>> ub = UrlBuilder("sdk-test.imgix.net")
  >>> ub.create_url(" <>[]{}|^%.jpg", params={'w': 100, 'h': 100}, options={'disable_path_encoding': True})  
  'https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100'
  ```
  Normally this would output a source URL like `https://sdk-test.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5E%25.jpg?h=100&2=100`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net/ <>[]{}|^%.jpg?h=100&w=100`.

* Testing the `create_scrset()` method
  ```python
  >>> from imgix import UrlBuilder
  >>> ub = UrlBuilder("sdk-test.imgix.net")
  >>> ub.create_srcset("image<>[]{} 123.png", widths=[100], options={'disable_path_encoding': True})
  'https://sdk-test.imgix.net/image<>[]{} 123.png?&w=100 100w'
  ```
  Normally this would output a source URL like `https://sdk-test.imgix.net/image%3C%3E%5B%5D%7B%7D%20123.png?&w=100 100w`, but since path encoding is disabled, it will output a source URL like `https://sdk-test.imgix.net//image<>[]{} 123.png?&w=100 100w`.

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [ ] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [ ] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [ ] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
